### PR TITLE
Fix SNMP interface creation on Zabbix API v5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Zabbix-auto-config is an utility that aims to automatically configure hosts, host groups and templates in the monitoring software [Zabbix](https://www.zabbix.com/).
 
-Note: This is only tested with Zabbix 4.0 LTS.
+Note: This is only tested with Zabbix 5.0 LTS.
 
 # Quick start
 

--- a/zabbix_auto_config/utils.py
+++ b/zabbix_auto_config/utils.py
@@ -63,8 +63,16 @@ def validate_host(host):
         for interface in host["interfaces"]:
             assert "endpoint" in interface, "'endpoint' is missing from interface"
             assert isinstance(interface["endpoint"], str), "'endpoint' is not a string"
+
             assert "type" in interface, "'type' is missing from interface"
             assert isinstance(interface["type"], int) and 1 <= interface["type"] <= 4, "'type' is not in range 1-4"
+            if interface["type"] == 2:
+                # SNMP interfaces require a 'details' parameter since Zabbix 5.0.
+                assert "details" in interface, "'details' is missing from interface"
+                assert isinstance(interface["details"], dict), "'details' is not a dictionary"
+            else:
+                assert "details" not in interface, "'details' is present on non-SNMP interface"
+
             assert "port" in interface, "'port' is missing from interface"
             assert isinstance(interface["port"], str), "'port' is not a string"
 


### PR DESCRIPTION
The [details parameter is required](https://www.zabbix.com/documentation/5.0/manual/api/reference/hostinterface/object) for SNMP interfaces in v5.  When creating an SNMP interface and no details are passed, default to a SNMPv2c interface utilizing the `{$SNMP_COMMUNITY}` macro.