### PR TITLE
Update quickstart/Don't use decommissioned container image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 .vscode/
 
 config.ini
+zabbix.yaml

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ This is a crash course in how to quickly get this application up and running in 
 
 ## Containers
 
-Use podman/docker.
+Use podman. Beware: There is a bug in podman 2.2.x. Use older/newer version.
 
 ```bash
-podman run -d -p 80:80 zabbix/zabbix-appliance:ubuntu-4.0-latest
-podman run -d --name postgres -p 5432:5432 -e POSTGRES_USER=username -e POSTGRES_DB=mydatabase -e POSTGRES_PASSWORD=secret library/postgres:latest
+ZABBIX_PASSWORD=secret envsubst < zabbix.template.yaml > zabbix.yaml
+podman play kube zabbix.yaml
 ```
 
 ## Zabbix web
@@ -32,7 +32,9 @@ For automatic linking in templates you could create the templates:
 ## Database
 
 ```bash
-PGPASSWORD=secret psql -h localhost -U postgres -p 5432 -U username mydatabase << EOF
+PGPASSWORD=secret psql -h localhost -U postgres -p 5432 -U zabbix << EOF
+CREATE DATABASE zac;
+\c zac
 CREATE TABLE hosts (
     data jsonb
 );
@@ -48,7 +50,8 @@ EOF
 python3 -m venv venv
 . venv/bin/activate
 pip install -e .
-cat config.sample.ini | perl -pe 's/^dryrun = true$/dryrun = false/g' > config.ini
+cat config.sample.ini > config.ini
+sed -i 's/^dryrun = true$/dryrun = false/g' config.ini
 mkdir -p /path/to/source_collector_dir/ /path/to/host_modifier_dir/ /path/to/map_dir/
 cat > /path/to/source_collector_dir/mysource.py << EOF
 HOSTS = [

--- a/config.sample.ini
+++ b/config.sample.ini
@@ -1,11 +1,11 @@
 [zac]
 source_collector_dir = /path/to/source_collector_dir/
 host_modifier_dir = /path/to/host_modifier_dir/
-db_uri = dbname='mydatabase' user='username' host='localhost' password='secret' port=5432 connect_timeout=2
+db_uri = dbname='zac' user='zabbix' host='localhost' password='secret' port=5432 connect_timeout=2
 
 [zabbix]
 map_dir = /path/to/map_dir/
-url = http://localhost
+url = http://localhost:8080
 username = Admin
 password = zabbix
 dryrun = true

--- a/zabbix.template.yaml
+++ b/zabbix.template.yaml
@@ -1,0 +1,52 @@
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: zabbix
+spec:
+  containers:
+    - image: docker.io/zabbix/zabbix-web-nginx-pgsql:5.0-alpine-latest
+      name: zabbix-web-nginx
+      env:
+        - name: DB_SERVER_HOST
+          value: 127.0.0.1
+        - name: PHP_TZ
+          value: Europe/Oslo
+        - name: POSTGRES_DB
+          value: zabbix
+        - name: POSTGRES_PASSWORD
+          value: ${ZABBIX_PASSWORD}
+        - name: POSTGRES_USER
+          value: zabbix
+        - name: ZBX_SERVER_HOST
+          value: 127.0.0.1
+      ports:
+        - containerPort: 8080
+          hostPort: 8080
+          protocol: TCP
+    - image: docker.io/library/postgres:latest
+      name: postgres
+      env:
+        - name: POSTGRES_DB
+          value: zabbix
+        - name: POSTGRES_PASSWORD
+          value: ${ZABBIX_PASSWORD}
+        - name: POSTGRES_USER
+          value: zabbix
+      ports:
+        - containerPort: 5432
+          hostPort: 5432
+          protocol: TCP
+    - image: docker.io/zabbix/zabbix-server-pgsql:5.0-alpine-latest
+      name: zabbix-server
+      env:
+        - name: DB_SERVER_HOST
+          value: 127.0.0.1
+        - name: POSTGRES_DB
+          value: zabbix
+        - name: POSTGRES_PASSWORD
+          value: ${ZABBIX_PASSWORD}
+        - name: POSTGRES_USER
+          value: zabbix
+  restartPolicy: Never


### PR DESCRIPTION
Fixes #21

Tested with the new podman 3.0.1. I'm fairly sure only the current podman 2.2.x series is bugged when using play kube.