### PR TITLE
Add ability to tag hosts

### DIFF
--- a/config.sample.ini
+++ b/config.sample.ini
@@ -10,6 +10,7 @@ username = Admin
 password = zabbix
 dryrun = true
 failsafe = 20
+tags_prefix = zac_
 
 [source-collector-mysource]
 module_name = mysource

--- a/zabbix_auto_config/utils.py
+++ b/zabbix_auto_config/utils.py
@@ -19,6 +19,15 @@ def is_valid_ip(ip):
         return False
 
 
+def zabbix_tags2zac_tags(zabbix_tags):
+    return {tuple(tag.values()) for tag in zabbix_tags}
+
+
+def zac_tags2zabbix_tags(zac_tags):
+    zabbix_tags = [{"tag": tag[0], "value": tag[1]} for tag in zac_tags]
+    return zabbix_tags
+
+
 def validate_host(host):
     # Host cannot have any other keys than these
 
@@ -32,7 +41,8 @@ def validate_host(host):
         "properties",
         "proxy_pattern",
         "siteadmins",
-        "sources"
+        "sources",
+        "tags",
     ]
 
     assert isinstance(host, dict), "Host is not a dictionary"
@@ -94,6 +104,12 @@ def validate_host(host):
         assert isinstance(host["siteadmins"], list), "'siteadmins' is not a list"
         for siteadmin in host["siteadmins"]:
             assert isinstance(siteadmin, str), "Found siteadmin that isn't a string"
+
+    if "tags" in host:
+        assert isinstance(host["tags"], list), "'tags' is not a list"
+        for tag in host["tags"]:
+            assert len(tag) == 2, f"Found tag that isn't a key/value pair. Length: {len(tag)}"
+            assert all(isinstance(item, str) for item in tag), f"Found nonstring in tag: {tag}"
 
 
 def read_map_file(path):


### PR DESCRIPTION
This is related to #23

This PR tries to be readable, maintainable and configurable. It also logs when host tags are changed. Only tag names that start with the new config value `tags_prefix` will be touched/synchronized.

Note regarding tags: Tags in Zabbix are name/value pairs. Names are not unique, but the name/value combination must be unique.

Zabbix internally uses objects like `{"tag": "foo", "value": "123"}`, but this PR uses a simpler `["foo", "123"]` object.