### PR TITLE
Fix missing variable update

### DIFF
--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -774,7 +774,7 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
 
     def do_update(self):
         managed_hostgroup_names = set(itertools.chain.from_iterable(self.property_hostgroup_map.values()))
-        managed_hostgroup_names.union(set(itertools.chain.from_iterable(self.siteadmin_hostgroup_map.values())))
+        managed_hostgroup_names.update(itertools.chain.from_iterable(self.siteadmin_hostgroup_map.values()))
         zabbix_hostgroups = {}
         for zabbix_hostgroup in self.api.hostgroup.get(output=["name", "groupid"]):
             zabbix_hostgroups[zabbix_hostgroup["name"]] = zabbix_hostgroup["groupid"]


### PR DESCRIPTION
Fixes a missing variable update. Resolves #28 

This might lead to changes in Zabbix, if the bug has lead to hosts/hostgroups not being updated/removed properly.