### PR TITLE
Health data

### DIFF
--- a/config.sample.ini
+++ b/config.sample.ini
@@ -2,6 +2,7 @@
 source_collector_dir = path/to/source_collector_dir/
 host_modifier_dir = path/to/host_modifier_dir/
 db_uri = dbname='zac' user='zabbix' host='localhost' password='secret' port=5432 connect_timeout=2
+health_file = /tmp/zac_health.json
 
 [zabbix]
 map_dir = path/to/map_dir/


### PR DESCRIPTION
Intended to fix #7

Adds a new config option `health_file`. This could point to a file, e.g: `/tmp/zac_health.json`.

At intervals the health file will contain something like this:
```json
{
  "date": "2022-01-06T23:19:15",
  "date_unixtime": 1641507555,
  "pid": 2987176,
  "cwd": "/home/zabbix/zabbix-auto-config",
  "all_ok": true,
  "processes": [
    {
      "name": "mysource",
      "pid": 2987217,
      "alive": true,
      "ok": true
    },
    {
      "name": "othersource",
      "pid": 2987218,
      "alive": true,
      "ok": true
    },
    {
      "name": "source-handler",
      "pid": 2987219,
      "alive": true,
      "ok": true
    },
    {
      "name": "source-merger",
      "pid": 2987221,
      "alive": true,
      "ok": true
    },
    {
      "name": "zabbix-host-updater",
      "pid": 2987226,
      "alive": true,
      "ok": true
    },
    {
      "name": "zabbix-hostgroup-updater",
      "pid": 2987231,
      "alive": true,
      "ok": true
    },
    {
      "name": "zabbix-template-updater",
      "pid": 2987236,
      "alive": true,
      "ok": true
    }
  ],
  "queues": [
    {
      "size": 0
    },
    {
      "size": 0
    }
  ]
}
```