### PR TITLE
Fix interface type error.

### DIFF
--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -447,7 +447,7 @@ class ZabbixHostUpdater(ZabbixUpdater):
                 parameters["dns"] = interface.endpoint
                 parameters["ip"] = ""
 
-            if "details" in interface:
+            if interface.details:
                 parameters["details"] = interface.details
 
             if old_id:


### PR DESCRIPTION
Fix another instance of `interface["foo"]`.