### PR TITLE
Remove `Optional[]` types from `models.Host` fields & add tests

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -72,4 +72,9 @@ def invalid_hosts():
                 },
             ],
         },
+        {
+            "enabled": True,
+            "hostname": "invalid-importance.example.com",
+            "importance": -1,
+        },
     ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -66,6 +66,40 @@ class TestModels(unittest.TestCase):
         ]
 
 
+    def test_host_merge(self):
+        """Tests merging of Hosts"""
+        host = self.find_host_by_hostname(self.full_hosts, "foo")
+        h1 = models.Host(**host)
+        host["enabled"] = False
+        host["properties"] = {"prop2", "prop3"}
+        host["siteadmins"] = {"bob@example.com", "chuck@example.com"}
+        host["sources"] = {"source2", "source3"}
+        host["tags"] = [["tag2", "y"], ["tag3", "z"]]
+        host["importance"] = 2
+        # TODO: interfaces
+        # TODO: proxy_pattern
+        host["inventory"] = {"foo": "bar", "baz": "qux"}
+        h2 = models.Host(**host)
+        h1.merge(h2)
+        assert h1.enabled
+        assert h1.properties == {"prop1", "prop2", "prop3"}
+        assert h1.siteadmins == {
+            "alice@example.com",
+            "bob@example.com",
+            "chuck@example.com",
+        }
+        assert h1.sources == {"source1", "source2", "source3"}
+        assert h1.tags == {("tag1", "x"), ("tag2", "y"), ("tag3", "z")}
+        assert h1.importance == 1
+        assert h1.inventory == {"foo": "bar", "baz": "qux"}
+
+    def test_host_merge_invalid(self):
+        """Tests merging of Host with incorrect type"""
+        host = self.find_host_by_hostname(self.full_hosts, "foo")
+        h1 = models.Host(**host)
+        with pytest.raises(TypeError):
+            h1.merge(object())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,6 +52,19 @@ class TestModels(unittest.TestCase):
         assert exc_info.value.errors() == [{'loc': ('interfaces',),
                                             'msg': 'No duplicate interface types: [1, 1]',
                                             'type': 'assertion_error'}]
+    def test_invalid_importance(self):
+        host = self.find_host_by_hostname(self.invalid_hosts, "invalid-importance")
+        with pytest.raises(ValidationError) as exc_info:
+            models.Host(**host)
+        assert exc_info.value.errors() == [
+            {
+                "loc": ("importance",),
+                "msg": "ensure this value is greater than or equal to 0",
+                "type": "value_error.number.not_ge",
+                "ctx": {"limit_value": 0},
+            }
+        ]
+
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -67,9 +67,11 @@ class TestModels(unittest.TestCase):
 
 
     def test_host_merge(self):
-        """Tests merging of Hosts"""
+        """Tests Host.merge()"""
         host = self.find_host_by_hostname(self.full_hosts, "foo")
         h1 = models.Host(**host)
+
+        host["hostname"] = "bar.example.com"
         host["enabled"] = False
         host["properties"] = {"prop2", "prop3"}
         host["siteadmins"] = {"bob@example.com", "chuck@example.com"}
@@ -80,7 +82,10 @@ class TestModels(unittest.TestCase):
         # TODO: proxy_pattern
         host["inventory"] = {"foo": "bar", "baz": "qux"}
         h2 = models.Host(**host)
+
         h1.merge(h2)
+
+        assert h1.hostname == "foo.example.com"
         assert h1.enabled
         assert h1.properties == {"prop1", "prop2", "prop3"}
         assert h1.siteadmins == {
@@ -94,7 +99,7 @@ class TestModels(unittest.TestCase):
         assert h1.inventory == {"foo": "bar", "baz": "qux"}
 
     def test_host_merge_invalid(self):
-        """Tests merging of Host with incorrect type"""
+        """Tests Host.merge() with incorrect argument type"""
         host = self.find_host_by_hostname(self.full_hosts, "foo")
         h1 = models.Host(**host)
         with pytest.raises(TypeError):

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -81,18 +81,29 @@ class Host(BaseModel):
     enabled: bool
     hostname: str
 
-    importance: Optional[conint(ge=0)]
-    interfaces: Optional[List[Interface]] = []
-    inventory: Optional[Dict[str, str]] = {}
+    importance: Optional[conint(ge=0)]  # type: ignore # mypy blows up: https://github.com/samuelcolvin/pydantic/issues/156#issuecomment-614748288
+    interfaces: List[Interface] = []
+    inventory: Dict[str, str] = {}
     macros: Optional[None] = None  # TODO: What should macros look like?
-    properties: Optional[Set[str]] = set()
-    proxy_pattern: Optional[str]
-    siteadmins: Optional[Set[str]] = set()
-    sources: Optional[Set[str]] = set()
-    tags: Optional[Set[Tuple[str, str]]] = set()
+    properties: Set[str] = set()
+    proxy_pattern: Optional[str]  # NOTE: replace with Optional[typing.Pattern]?
+    siteadmins: Set[str] = set()
+    sources: Set[str] = set()
+    tags: Set[Tuple[str, str]] = set()
 
     class Config:
         validate_assignment = True
+
+    @validator("*", pre=True)
+    def none_defaults_to_field_default(cls, v: Any, field: ModelField) -> Any:
+        """The field's default value or factory is returned if the value is None."""
+        # TODO: add field type check
+        if v is None:
+            if field.default:
+                return field.default
+            elif field.default_factory:
+                return field.default_factory()
+        return v
 
     # pylint: disable=no-self-use, no-self-argument
     @validator("interfaces")

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -96,6 +96,7 @@ class Host(BaseModel):
     class Config:
         validate_assignment = True
 
+    # pylint: disable=no-self-use, no-self-argument
     @validator("*", pre=True)
     def none_defaults_to_field_default(cls, v: Any, field: ModelField) -> Any:
         """The field's default value or factory is returned if the value is None."""

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -99,9 +99,9 @@ class Host(BaseModel):
         """The field's default value or factory is returned if the value is None."""
         # TODO: add field type check
         if v is None:
-            if field.default:
+            if field.default is not None:
                 return field.default
-            elif field.default_factory:
+            elif field.default_factory is not None:
                 return field.default_factory()
         return v
 

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -127,7 +127,7 @@ class Host(BaseModel):
         Merge other host into this one. The current hostname will be kept if they do not match.
         """
         if not isinstance(other, self.__class__):
-            raise ValueError(f"Can't merge with objects of other type: {type(other)}")
+            raise TypeError(f"Can't merge with objects of other type: {type(other)}")
 
         self.enabled = self.enabled or other.enabled
         # self.macros TODO

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -1,6 +1,7 @@
 import logging
 
 from typing import (
+    Any,
     Dict,
     List,
     Optional,
@@ -16,6 +17,7 @@ from pydantic import (
     validator,
     Extra,
 )
+from pydantic.fields import ModelField
 
 from . import utils
 

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -110,19 +110,19 @@ class Host(BaseModel):
 
     # pylint: disable=no-self-use, no-self-argument
     @validator("interfaces")
-    def no_duplicate_interface_types(cls, v):
+    def no_duplicate_interface_types(cls, v: List[Interface]) -> List[Interface]:
         types = [interface.type for interface in v]
         assert len(types) == len(set(types)), f"No duplicate interface types: {types}"
         return v
 
     # pylint: disable=no-self-use, no-self-argument
     @validator("proxy_pattern")
-    def must_be_valid_regexp_pattern(cls, v):
+    def must_be_valid_regexp_pattern(cls, v: Optional[str]) -> Optional[str]:
         if v is not None:
             assert utils.is_valid_regexp(v), f"Must be valid regexp pattern: {v!r}"
         return v
 
-    def merge(self, other):
+    def merge(self, other: "Host") -> None:
         """
         Merge other host into this one. The current hostname will be kept if they do not match.
         """


### PR DESCRIPTION
# Changes
Most fields in the `Host` class have had their `Optional` type removed, and a new `"*"` validator has been added to ensure these fields can still be instantiated with `None` (ensuring backwards compatibility). The validator guarantees that these fields are _not_  `None` once the object itself has been instantiated, as it uses the field's default value or default factory to assign values to them.

Affected fields in `Host`:
- `interfaces`
- `inventory`
- `properties`
- `proxy_pattern`
- `siteadmins`
- `sources`
- `tags`

Furthermore, tests for `Host.merge()` as well as `Host.importance`**\*** have been added.
Since it's a bit unclear how `Host.proxy_pattern` and `Host.macros` should be handled when merging, they are not tested.

**\*** This probably could have been a separate pull request, but it's a _very_ minor change. See: c1cea92cbed8c3403e8394d5f6b6b7af502cc115



# Rationale
`Optional[<type>]` fields make `Host.merge()` dangerous to run without adding `None` checks for each field.

Required to make `Host.merge()` safe without removing `Optional` currently:

```py
if self.inventory is not None and other.inventory is not None: # this must be added
    for k, v in other.inventory.items():
        if k in self.inventory and v != self.inventory[k]:
            logging.warning("Same inventory ('%s') set multiple times for host: '%s'", k, self.hostname)
        else:
            self.inventory[k] = v
``` 
This `None` check does not currently exist (unsafe) and is one the primary motivations for making this pull request. `None` checks would have to be added to every single attribute access on both `self` and `other` for all fields that are not `Optional`.


With this pull request: 

```py
for k, v in other.inventory.items(): # other.inventory and self.inventory guaranteed to be a dict
    if k in self.inventory and v != self.inventory[k]:
        logging.warning("Same inventory ('%s') set multiple times for host: '%s'", k, self.hostname)
    else:
        self.inventory[k] = v
```


Removing the possibility for these fields to be `None` during runtime makes the code easier to reason with, as well as removing potential pitfalls related to `Optional` types.

In order to not break existing tests and functionality, a new `"*"` validator has been added which returns the field's default value or runs its default factory if it receives a `None` value.

