### PR TITLE
Rewrite Tests as Pytest Tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,4 +32,4 @@ jobs:
         run: |
           pip install -e .[test]
       - name: Test
-        run: python -m unittest discover -v tests
+        run: python -m pytest -vv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,20 @@
+import os
+import pytest
+
+
+@pytest.fixture(scope="function")
 def minimal_hosts():
-    return [
+    yield [
         {
             "enabled": True,
             "hostname": "foo.example.com",
         },
     ]
 
+
+@pytest.fixture(scope="function")
 def full_hosts():
-    return [
+    yield [
         {
             "enabled": True,
             "hostname": "foo.example.com",
@@ -38,8 +45,10 @@ def full_hosts():
         },
     ]
 
+
+@pytest.fixture(scope="function")
 def invalid_hosts():
-    return [
+    yield [
         {
             "enabled": True,
             "hostname": "invalid-proxy-pattern.example.com",
@@ -78,3 +87,11 @@ def invalid_hosts():
             "importance": -1,
         },
     ]
+
+
+@pytest.fixture(scope="function")
+def sample_config():
+    with open(
+        os.path.dirname(os.path.dirname(__file__)) + "/config.sample.toml"
+    ) as config:
+        yield config.read()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,27 +7,23 @@ from pydantic.error_wrappers import ValidationError
 
 import zabbix_auto_config.models as models
 
-class TestConfig(unittest.TestCase):
-    @staticmethod
-    def get_sample_config():
-        with open(os.path.dirname(os.path.dirname(__file__)) +
-                  "/config.sample.toml") as config:
-            return config.read()
 
-    def setUp(self):
-        self.sample_config = self.get_sample_config()
+def test_sample_config(sample_config):
+    models.Settings(**tomli.loads(sample_config))
 
-    def test_sample_config(self):
-        models.Settings(**tomli.loads(self.sample_config))
 
-    def test_invalid_config(self):
-        config = tomli.loads(self.sample_config)
-        config["foo"] = "bar"
-        with pytest.raises(ValidationError) as exc_info:
-            models.Settings(**config)
-        assert exc_info.value.errors() == [{'loc': ('foo',),
-                                            'msg': 'extra fields not permitted',
-                                            'type': 'value_error.extra'}]
+def test_invalid_config(sample_config):
+    config = tomli.loads(sample_config)
+    config["foo"] = "bar"
+    with pytest.raises(ValidationError) as exc_info:
+        models.Settings(**config)
+    assert exc_info.value.errors() == [
+        {
+            "loc": ("foo",),
+            "msg": "extra fields not permitted",
+            "type": "value_error.extra",
+        }
+    ]
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,110 +1,115 @@
-import unittest
-import zabbix_auto_config.models as models
-
 import pytest
 from pydantic.error_wrappers import ValidationError
-
-import fixtures
-
-class TestModels(unittest.TestCase):
-
-    @staticmethod
-    def find_host_by_hostname(hosts, hostname):
-        for host in hosts:
-            if host["hostname"].startswith(hostname):
-                return host
-        return None
-
-    def setUp(self):
-        self.minimal_hosts = fixtures.minimal_hosts()
-        self.full_hosts = fixtures.full_hosts()
-        self.invalid_hosts = fixtures.invalid_hosts()
-
-    def test_minimal_host(self):
-        for host in self.minimal_hosts:
-            models.Host(**host)
-
-    def test_full_host(self):
-        for host in self.full_hosts:
-            models.Host(**host)
-
-    def test_invalid_proxy_pattern(self):
-        host = self.find_host_by_hostname(self.invalid_hosts, "invalid-proxy-pattern")
-        with pytest.raises(ValidationError) as exc_info:
-            models.Host(**host)
-        assert exc_info.value.errors() == [{'loc': ('proxy_pattern',),
-                                            'msg': "Must be valid regexp pattern: '['",
-                                            'type': 'assertion_error'}]
+from zabbix_auto_config import models
 
 
-    def test_invalid_interface(self):
-        host = self.find_host_by_hostname(self.invalid_hosts, "invalid-interface")
-        with pytest.raises(ValidationError) as exc_info:
-            models.Host(**host)
-        assert exc_info.value.errors() == [{'loc': ('interfaces', 0, 'type'),
-                                            'msg': 'Interface of type 2 must have details set',
-                                            'type': 'value_error'}]
-
-    def test_duplicate_interface(self):
-        host = self.find_host_by_hostname(self.invalid_hosts, "duplicate-interface")
-        with pytest.raises(ValidationError) as exc_info:
-            models.Host(**host)
-        assert exc_info.value.errors() == [{'loc': ('interfaces',),
-                                            'msg': 'No duplicate interface types: [1, 1]',
-                                            'type': 'assertion_error'}]
-    def test_invalid_importance(self):
-        host = self.find_host_by_hostname(self.invalid_hosts, "invalid-importance")
-        with pytest.raises(ValidationError) as exc_info:
-            models.Host(**host)
-        assert exc_info.value.errors() == [
-            {
-                "loc": ("importance",),
-                "msg": "ensure this value is greater than or equal to 0",
-                "type": "value_error.number.not_ge",
-                "ctx": {"limit_value": 0},
-            }
-        ]
+def find_host_by_hostname(hosts, hostname):
+    for host in hosts:
+        if host["hostname"].startswith(hostname):
+            return host
+    return None
 
 
-    def test_host_merge(self):
-        """Tests Host.merge()"""
-        host = self.find_host_by_hostname(self.full_hosts, "foo")
-        h1 = models.Host(**host)
+def test_minimal_host(minimal_hosts):
+    for host in minimal_hosts:
+        models.Host(**host)
 
-        host["hostname"] = "bar.example.com"
-        host["enabled"] = False
-        host["properties"] = {"prop2", "prop3"}
-        host["siteadmins"] = {"bob@example.com", "chuck@example.com"}
-        host["sources"] = {"source2", "source3"}
-        host["tags"] = [["tag2", "y"], ["tag3", "z"]]
-        host["importance"] = 2
-        # TODO: interfaces
-        # TODO: proxy_pattern
-        host["inventory"] = {"foo": "bar", "baz": "qux"}
-        h2 = models.Host(**host)
 
-        h1.merge(h2)
+def test_full_host(full_hosts):
+    for host in full_hosts:
+        models.Host(**host)
 
-        assert h1.hostname == "foo.example.com"
-        assert h1.enabled
-        assert h1.properties == {"prop1", "prop2", "prop3"}
-        assert h1.siteadmins == {
-            "alice@example.com",
-            "bob@example.com",
-            "chuck@example.com",
+
+def test_invalid_proxy_pattern(invalid_hosts):
+    host = find_host_by_hostname(invalid_hosts, "invalid-proxy-pattern")
+    with pytest.raises(ValidationError) as exc_info:
+        models.Host(**host)
+    assert exc_info.value.errors() == [
+        {
+            "loc": ("proxy_pattern",),
+            "msg": "Must be valid regexp pattern: '['",
+            "type": "assertion_error",
         }
-        assert h1.sources == {"source1", "source2", "source3"}
-        assert h1.tags == {("tag1", "x"), ("tag2", "y"), ("tag3", "z")}
-        assert h1.importance == 1
-        assert h1.inventory == {"foo": "bar", "baz": "qux"}
-
-    def test_host_merge_invalid(self):
-        """Tests Host.merge() with incorrect argument type"""
-        host = self.find_host_by_hostname(self.full_hosts, "foo")
-        h1 = models.Host(**host)
-        with pytest.raises(TypeError):
-            h1.merge(object())
+    ]
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_invalid_interface(invalid_hosts):
+    host = find_host_by_hostname(invalid_hosts, "invalid-interface")
+    with pytest.raises(ValidationError) as exc_info:
+        models.Host(**host)
+    assert exc_info.value.errors() == [
+        {
+            "loc": ("interfaces", 0, "type"),
+            "msg": "Interface of type 2 must have details set",
+            "type": "value_error",
+        }
+    ]
+
+
+def test_duplicate_interface(invalid_hosts):
+    host = find_host_by_hostname(invalid_hosts, "duplicate-interface")
+    with pytest.raises(ValidationError) as exc_info:
+        models.Host(**host)
+    assert exc_info.value.errors() == [
+        {
+            "loc": ("interfaces",),
+            "msg": "No duplicate interface types: [1, 1]",
+            "type": "assertion_error",
+        }
+    ]
+
+
+def test_invalid_importance(invalid_hosts):
+    host = find_host_by_hostname(invalid_hosts, "invalid-importance")
+    with pytest.raises(ValidationError) as exc_info:
+        models.Host(**host)
+    assert exc_info.value.errors() == [
+        {
+            "loc": ("importance",),
+            "msg": "ensure this value is greater than or equal to 0",
+            "type": "value_error.number.not_ge",
+            "ctx": {"limit_value": 0},
+        }
+    ]
+
+
+
+def test_host_merge(full_hosts):
+    """Tests Host.merge()"""
+    host = find_host_by_hostname(full_hosts, "foo")
+    h1 = models.Host(**host)
+
+    host["hostname"] = "bar.example.com"
+    host["enabled"] = False
+    host["properties"] = {"prop2", "prop3"}
+    host["siteadmins"] = {"bob@example.com", "chuck@example.com"}
+    host["sources"] = {"source2", "source3"}
+    host["tags"] = [["tag2", "y"], ["tag3", "z"]]
+    host["importance"] = 2
+    # TODO: interfaces
+    # TODO: proxy_pattern
+    host["inventory"] = {"foo": "bar", "baz": "qux"}
+    h2 = models.Host(**host)
+
+    h1.merge(h2)
+
+    assert h1.hostname == "foo.example.com"
+    assert h1.enabled
+    assert h1.properties == {"prop1", "prop2", "prop3"}
+    assert h1.siteadmins == {
+        "alice@example.com",
+        "bob@example.com",
+        "chuck@example.com",
+    }
+    assert h1.sources == {"source1", "source2", "source3"}
+    assert h1.tags == {("tag1", "x"), ("tag2", "y"), ("tag3", "z")}
+    assert h1.importance == 1
+    assert h1.inventory == {"foo": "bar", "baz": "qux"}
+
+
+def test_host_merge_invalid(full_hosts):
+    """Tests Host.merge() with incorrect argument type"""
+    host = find_host_by_hostname(full_hosts, "foo")
+    h1 = models.Host(**host)
+    with pytest.raises(TypeError):
+        h1.merge(object())


### PR DESCRIPTION
This pull request rewrites all `unittest.TestCase` tests as pytest tests and uses pytest as the test runner in CI.

# Changes

* All `unittest.TestCase`-based tests have been rewritten as standalone `test_*` functions (pytest style).
* GitHub Actions workflow now runs the tests with pytest instead of unittest. 
* `tests/fixtures.py` renamed to `tests/conftest.py` so it is automatically imported by pytest.
  * As a part of this, fixtures are now proper pytest fixtures.
  * Fixtures are currently set to be function-scoped, which allows for modification of their return values without affecting other tests.

# Reason

The existing tests already use pytest functionality such as `pytest.raises`. Furthermore, the other Zabbix project, zabbix-cli, already runs its tests via pytest instead of unittest. Since pytest is already used to some degree in this project, it would probably be beneficial to more fully embrace pytest-style testing.

Using pytest with pytest-style tests allows tests to use useful features such as parametrization and fixtures going forward (see [pytest documentation](https://docs.pytest.org/en/7.1.x/how-to/unittest.html#pytest-features-in-unittest-testcase-subclasses) for more information).

# Going Forward

This is a pretty big change, and I understand if it's not something you want to prioritize right now. 👍