### PR TITLE
Create Templates-* host groups

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -20,8 +20,11 @@ managed_inventory = ["location"]
 #hostgroup_disabled = "All-auto-disabled-hosts"
 #hostgroup_source_prefix = "Source-"
 #hostgroup_importance_prefix = "Importance-"
-#hostgroup_siteadmin_prefix = "Siteadmin-"
-#hostgroup_templates_prefix = "Templates-"
+#hostgroup_siteadmin_hosts_prefix = "Siteadmin-"
+#hostgroup_siteadmin_templates_prefix = "Templates-"
+#mapping_file_prefix = "Siteadmin-"
+#manage_hosts_hostgroups = true
+#manage_templates_hostgroups = true
 
 [source_collectors.mysource]
 module_name = "mysource"

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -20,6 +20,8 @@ managed_inventory = ["location"]
 #hostgroup_disabled = "All-auto-disabled-hosts"
 #hostgroup_source_prefix = "Source-"
 #hostgroup_importance_prefix = "Importance-"
+#hostgroup_siteadmin_prefix = "Siteadmin-"
+#hostgroup_templates_prefix = "Templates-"
 
 [source_collectors.mysource]
 module_name = "mysource"

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -41,6 +41,8 @@ class ZabbixSettings(BaseSettings):
 
     hostgroup_source_prefix: str = "Source-"
     hostgroup_importance_prefix: str = "Importance-"
+    hostgroup_siteadmin_prefix: str = "Siteadmin-"
+    hostgroup_templates_prefix: str = "Templates-"
 
 class ZacSettings(BaseSettings):
     source_collector_dir: str
@@ -83,7 +85,7 @@ class Host(BaseModel):
     enabled: bool
     hostname: str
 
-    importance: Optional[conint(ge=0)]  # type: ignore # mypy blows up: https://github.com/samuelcolvin/pydantic/issues/156#issuecomment-614748288
+    importance: Optional[conint(ge=0)]  # type: ignore # mypy blows up: https://github.com/pydantic/pydantic/issues/239 & https://github.com/pydantic/pydantic/issues/156
     interfaces: List[Interface] = []
     inventory: Dict[str, str] = {}
     macros: Optional[None] = None  # TODO: What should macros look like?

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -41,8 +41,16 @@ class ZabbixSettings(BaseSettings):
 
     hostgroup_source_prefix: str = "Source-"
     hostgroup_importance_prefix: str = "Importance-"
-    hostgroup_siteadmin_prefix: str = "Siteadmin-"
-    hostgroup_templates_prefix: str = "Templates-"
+    hostgroup_siteadmin_hosts_prefix: str = "Siteadmin-"
+    hostgroup_siteadmin_templates_prefix: str = "Templates-"
+
+    # The prefix (if any) for groups in the mapping file
+    mapping_file_prefix: str = "Siteadmin-"
+
+    # Create/delete host groups
+    manage_hosts_hostgroups: bool = True
+    manage_templates_hostgroups: bool = True
+
 
 class ZacSettings(BaseSettings):
     source_collector_dir: str

--- a/zabbix_auto_config/utils.py
+++ b/zabbix_auto_config/utils.py
@@ -2,7 +2,7 @@ import ipaddress
 import logging
 from pathlib import Path
 import re
-from typing import Dict, Iterable, List, Sequence, Set, Tuple, Union
+from typing import Dict, Iterable, List, Set, Tuple, Union
 
 
 def is_valid_regexp(pattern: str):
@@ -84,3 +84,67 @@ def read_map_file(path: Union[str, Path]) -> Dict[str, List[str]]:
             )
         _map[key] = values_dedup
     return _map
+
+
+def with_prefix(
+    text: str, prefix: str, old_prefix: str = "", lower: bool = False
+) -> str:
+    """Ensures `text` starts with `prefix`.
+
+    If `old_prefix` is given, it will be replaced with `prefix`.
+
+    If `lower` is True, `text` will be lowercased before new prefix is added.
+
+    Examples:
+        >>> with_prefix("foo", "bar-")
+        'bar-foo'
+        >>> with_prefix("baz-foo", "bar-", "baz-")
+        'bar-foo'
+        >>> with_prefix("Foo", "Bar-", lower=True)
+        'Bar-foo'
+        >>> with_prefix("Baz-Foo", "Bar-", "Baz-", lower=True)
+        'Bar-foo'
+
+    Parameters
+    ----
+    text: str
+        The text to format.
+    prefix: str
+        The prefix to add to `text`.
+    old_prefix: str, optional
+        If given, `old_prefix` will be replaced with `prefix`.
+    lower: bool
+        If True, `text` will be converted to lowercase before adding the prefix,
+        but after comparing to `old_prefix`.
+
+    Returns
+    -------
+    str
+        The formatted string.
+    """
+    if old_prefix and text.startswith(old_prefix):
+        text = text[len(old_prefix) :]
+    if not text.startswith(prefix):
+        if lower:
+            text = text.lower()
+        return f"{prefix}{text}"
+    return text
+
+
+def mapping_values_with_prefix(
+    m: Dict[str, Union[List[str], str]],
+    prefix: str,
+    old_prefix: str = "",
+    lower: bool = False,
+) -> Dict[str, List[str]]:
+    """Calls `with_prefix` on all values in the mapping `m`."""
+    m = m.copy()  # don't modify the original mapping
+    for key, value in m.items():
+        if isinstance(value, str):
+            value = [value]
+        new_values = []
+        for v in value:
+            new_value = with_prefix(v, prefix, old_prefix, lower)
+            new_values.append(new_value)
+        m[key] = new_values
+    return m


### PR DESCRIPTION
This pull request makes the application create `Templates-*` host groups in addition to `Siteadmin-*` host groups. Additionally, the prefix used to create the templates groups can be configured via the new `hostgroup_templates_prefix` configuration option. 

Should the prefix in the mapping file ever change from `Siteadmin-` in the future, it must be changed accordingly in the config with the new `hostgroup_siteadmin_prefix` configuration option. We rely on this value to inform the program of how to construct the templates host group names from the siteadmin group names in the file.

## Primary changes

* Added functionality for automatically creating `Templates-*` host groups
* Added config option for adjusting the prefix used to create the templates host groups (default: `Templates-`)
* Added config option to specify what the currently used prefix for siteadmin groups is (default: `Siteadmin-`)
* Added tests for new utils functions for constructing host group names.

## Other changes

* Added missing logging calls for certain actions when run in dryrun mode.
* Fixed comment in `utils.py` regarding constrained types.

## Questions

Should there be a toggle for creating the `Templates-*` group, or do we make it mandatory for these groups to be created?