### PR TITLE
Fix misplaces ports in compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,5 @@ services:
       - "POSTGRES_DB=zabbix"
       - "POSTGRES_PASSWORD=${ZABBIX_PASSWORD:?Need env: ZABBIX_PASSWORD}"
       - "POSTGRES_USER=zabbix"
+    ports:
+      - "10051:10051"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "POSTGRES_DB=zabbix"
       - "POSTGRES_PASSWORD=${ZABBIX_PASSWORD:?Need env: ZABBIX_PASSWORD}"
       - "POSTGRES_USER=zabbix"
+    ports:
+      - "5432:5432"
 
   zabbix-web-nginx:
     image: "docker.io/zabbix/zabbix-web-nginx-pgsql:${TAG:?Need env: TAG}"
@@ -31,5 +33,3 @@ services:
       - "POSTGRES_DB=zabbix"
       - "POSTGRES_PASSWORD=${ZABBIX_PASSWORD:?Need env: ZABBIX_PASSWORD}"
       - "POSTGRES_USER=zabbix"
-    ports:
-      - "5432:5432"


### PR DESCRIPTION
I noticed that the ports part is put on the wrong container. It should be moved to actually expose the database.