### PR TITLE
Add option functionality to create additional siteadmin host groups

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -20,6 +20,9 @@ managed_inventory = ["location"]
 #hostgroup_disabled = "All-auto-disabled-hosts"
 #hostgroup_source_prefix = "Source-"
 #hostgroup_importance_prefix = "Importance-"
+# hostgroup_siteadmin_prefix = "Hostgroup-"
+# mapping_file_prefix = "Hostgroup-"
+# extra_siteadmin_hostgroup_prefixes = []
 
 [source_collectors.mysource]
 module_name = "mysource"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+from typing import Iterable
 import pytest
 
 
@@ -95,3 +97,27 @@ def sample_config():
         os.path.dirname(os.path.dirname(__file__)) + "/config.sample.toml"
     ) as config:
         yield config.read()
+
+
+@pytest.fixture
+def hostgroup_map_file(tmp_path: Path) -> Iterable[Path]:
+    contents = hostgroup_map = """
+# This file defines assosiation between siteadm fetched from Nivlheim and hostsgroups in Zabbix.
+# A siteadm can be assosiated only with one hostgroup or usergroup.
+# Example: <siteadm>:<host/user groupname>
+#
+#****************************************************************************************
+# ATT: First letter will be capitilazed, leading and trailing spaces will be removed and 
+#      spaces within the hostgroupname will be replaced with "-" by the script automatically 
+#****************************************************************************************
+#
+user1@example.com:Hostgroup-user1-primary
+#
+user2@example.com:Hostgroup-user2-primary
+user2@example.com:Hostgroup-user2-secondary
+#
+user3@example.com:Hostgroup-user3-primary
+"""
+    map_file_path = tmp_path / "siteadmin_hostgroup_map.txt"
+    map_file_path.write_text(contents)
+    yield map_file_path

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -42,6 +42,22 @@ class ZabbixSettings(BaseSettings):
     hostgroup_source_prefix: str = "Source-"
     hostgroup_importance_prefix: str = "Importance-"
 
+    # The prefix (if any) for the managed host groups in Zabbix
+    # This group is used to store the hosts that are managed by ZAC
+    hostgroup_siteadmin_prefix: str = "Hostgroup-"
+
+    # The prefix (if any) for groups in the mapping file
+    # This is required to be able to control the prefix of the groups
+    # when creating them in Zabbix. Must match with the prefix in the
+    # mapping file.
+    mapping_file_prefix: str = "Hostgroup-"
+
+    # Prefixes for extra host groups to create
+    # These groups are not used by ZAC, but ZAC has the ability to
+    # create them based on the mapping file
+    extra_siteadmin_hostgroup_prefixes: Set[str] = set()
+
+
 class ZacSettings(BaseSettings):
     source_collector_dir: str
     host_modifier_dir: str
@@ -83,7 +99,7 @@ class Host(BaseModel):
     enabled: bool
     hostname: str
 
-    importance: Optional[conint(ge=0)]  # type: ignore # mypy blows up: https://github.com/samuelcolvin/pydantic/issues/156#issuecomment-614748288
+    importance: Optional[conint(ge=0)]  # type: ignore # mypy blows up: https://github.com/pydantic/pydantic/issues/239 & https://github.com/pydantic/pydantic/issues/156
     interfaces: List[Interface] = []
     inventory: Dict[str, str] = {}
     macros: Optional[None] = None  # TODO: What should macros look like?


### PR DESCRIPTION
Reworked from #47.

This pull request adds support for cases (such as ours) where administrators want to create additional host groups with a different prefix for each host group in the mapping file. The option is exposed as a TOML array that takes an arbitrary number of extra group prefixes. By default, the array is empty, disabling this feature.

Given the new config options:

```toml
hostgroup_siteadmin_prefix = "Hostgroup-"
mapping_file_prefix = "Hostgroup-"
extra_siteadmin_hostgroup_prefixes = ["Templates-", "Foo-", "Bar-"]
```
and the siteadmin mapping file:

```
bob@example.com:Hostgroup-bob-hosts
```

We expect the following groups to be created for this mapping file entry:

* Hostgroup-bob-hosts
* Templates-bob-hosts
* Foo-bob-hosts
* Bar-bob-hosts

Which we observe happening:

<img width="547" alt="image" src="https://user-images.githubusercontent.com/107681714/223109697-eedcce4c-10c6-4b6c-a2d6-e44ef7a5d873.png">



## Differences from #47 

With this approach, we do not modify the logic for creating the standard host groups. It is explicit in the code where we create the extra host groups, instead of the shoe-horned creation seen in the previous implementation. Furthermore, more validation has been added to ensure that `mapping_file_prefix` is actually found in the mapping file, so that we don't add double prefixes to the new host group names.
