### PR TITLE
Allow extra config fields and log warning for each extra field

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,30 +1,37 @@
-import os
-import unittest
+import logging
 import tomli
 
 import pytest
-from pydantic.error_wrappers import ValidationError
-
+from pydantic import Extra
 import zabbix_auto_config.models as models
 
 
-def test_sample_config(sample_config):
+def test_sample_config(sample_config: str):
     models.Settings(**tomli.loads(sample_config))
 
 
-def test_invalid_config(sample_config):
+def test_config_extra_field(sample_config: str, caplog: pytest.LogCaptureFixture):
     config = tomli.loads(sample_config)
     config["foo"] = "bar"
-    with pytest.raises(ValidationError) as exc_info:
+    models.Settings(**config)
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == "WARNING"
+    assert record.levelno == logging.WARNING
+    assert "'foo'" in record.message
+
+
+def test_config_extra_field_allowed(
+    sample_config: str, caplog: pytest.LogCaptureFixture
+):
+    config = tomli.loads(sample_config)
+    config["foo"] = "bar"
+
+    # Allow extra fields for this test
+    original_extra = models.Settings.__config__.extra
+    try:
+        models.Settings.__config__.extra = Extra.allow
         models.Settings(**config)
-    assert exc_info.value.errors() == [
-        {
-            "loc": ("foo",),
-            "msg": "extra fields not permitted",
-            "type": "value_error.extra",
-        }
-    ]
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert len(caplog.records) == 0
+    finally:
+        models.Settings.__config__.extra = original_extra

--- a/zabbix_auto_config/__init__.py
+++ b/zabbix_auto_config/__init__.py
@@ -102,9 +102,9 @@ def log_process_status(processes):
 
 
 def main():
+    logging.basicConfig(format='%(asctime)s %(levelname)s [%(processName)s %(process)d] [%(name)s] %(message)s', datefmt="%Y-%m-%dT%H:%M:%S%z", level=logging.DEBUG)
     config = get_config()
 
-    logging.basicConfig(format='%(asctime)s %(levelname)s [%(processName)s %(process)d] [%(name)s] %(message)s', datefmt="%Y-%m-%dT%H:%M:%S%z", level=logging.DEBUG)
     multiprocessing_logging.install_mp_handler()
     logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
 


### PR DESCRIPTION
This pull request makes the config parsing less strict, and allows for passing in extra fields, which by default are ignored. Each extra field passed to the config is logged with a WARNING level. 

This makes it easier to use the same config file across different versions. Particularly if a config field is removed in the future, older versions of the config can still be used, and users are made aware of the removed fields with the generated warnings.

## Example

Given the following config with the two extra fields `zac.my_extra_field_zabbix` and `zabbix.my_extra_field_zabbix`:

```toml
[zac]
# ...
my_extra_field_zac = ["yeah"]

[zabbix]
# ...
my_extra_field_zabbix = true
```

The following logs are generated:

```
2023-03-15T15:26:09+0100 WARNING [MainProcess 36778] [root] ZacSettings: Got unknown config field 'my_extra_field_zac'.
2023-03-15T15:26:09+0100 WARNING [MainProcess 36778] [root] ZabbixSettings: Got unknown config field 'my_extra_field_zabbix'.
```

`BaseSettings` objects with `extra = "allow"` do not log extra fields.


## Notes

This PR configures the logger _before_ loading the config, so that the generated logs use the same formatting as every other log.