### PR TITLE
Fix missing raw string

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def full_hosts():
             "inventory": None,
             "macros": None,
             "properties": {"prop1", "prop2"},
-            "proxy_pattern": "^zbx-proxy\d+\.example\.com$",
+            "proxy_pattern": r"^zbx-proxy\d+\.example\.com$",
             "siteadmins": {"bob@example.com", "alice@example.com"},
             "sources": {"source1", "source2"},
             "tags": [["tag1", "x"], ["tag2", "y"]],


### PR DESCRIPTION
The tests complain that:
```
tests/conftest.py:43
  zabbix-auto-config/tests/conftest.py:43: DeprecationWarning: invalid escape sequence '\d'
    "proxy_pattern": "^zbx-proxy\d+\.example\.com$",

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

This makes it a raw string.