### PR TITLE
Prevent unbounded queue growth

### DIFF
--- a/zabbix_auto_config/__init__.py
+++ b/zabbix_auto_config/__init__.py
@@ -132,7 +132,7 @@ def main():
     source_hosts_queues = []
     source_collectors = get_source_collectors(config)
     for source_collector in source_collectors:
-        source_hosts_queue = multiprocessing.Queue()
+        source_hosts_queue = multiprocessing.Queue(maxsize=1)
         process = processing.SourceCollectorProcess(source_collector["name"], state_manager.dict(), source_collector["module"], source_collector["config"], source_hosts_queue)
         source_hosts_queues.append(source_hosts_queue)
         processes.append(process)

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -129,8 +129,12 @@ class SourceCollectorProcess(BaseProcess):
             "source": self.name,
             "hosts": valid_hosts,
         }
-
-        self.source_hosts_queue.put(source_hosts)
+        if self.source_hosts_queue.full():
+            logging.warning(
+                "Collection outpacing processing. Consider extending the update interval."
+            )
+            utils.drain_queue(self.source_hosts_queue)
+        self.source_hosts_queue.put_nowait(source_hosts)
 
         logging.info("Done collecting %d hosts from source, '%s', in %.2f seconds. Next update: %s", len(valid_hosts), self.name, time.time() - start_time, self.next_update.isoformat(timespec="seconds"))
 

--- a/zabbix_auto_config/utils.py
+++ b/zabbix_auto_config/utils.py
@@ -1,10 +1,11 @@
 import copy
 import ipaddress
 import logging
+import multiprocessing
 from pathlib import Path
+import queue
 import re
 from typing import Dict, Iterable, List, Mapping, MutableMapping, Set, Tuple, Union
-
 
 def is_valid_regexp(pattern: str):
     try:
@@ -150,3 +151,12 @@ def mapping_values_with_prefix(
             new_values.append(new_value)
         m[key] = new_values
     return m
+
+
+def drain_queue(q: multiprocessing.Queue) -> None:
+    """Drains a multiprocessing.Queue by calling `queue.get_nowait()` until the queue is empty."""
+    while not q.empty():
+        try:
+            q.get_nowait()
+        except queue.Empty:
+            break


### PR DESCRIPTION
Fixes #60 by draining the queue if new hosts are collected before the previous hosts in the queue have been consumed. To prevent future unbounded queue growth due to developer errors, the max size of these queues have been set to 1, which makes it explicit that these queues should never contain more than a single collection result at any point.

A warning log message is now generated when the collection rate outpaces the processing rate.