### PR TITLE
Require pydantic>=1.0.0,<2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.8
 install_requires =
     multiprocessing-logging == 0.3.1
     psycopg2
-    pydantic
+    pydantic >=1.0.0,<2.0.0
     pyzabbix
     requests
     tomli


### PR DESCRIPTION
Pydantic v2 breaks a bunch of stuff which requires some non-trivial changes. Before we can fix that, we need to restrict the required version to be anything between 1.0.0 and 2.0.0 for now, so new installations of the application does not use >=2.0.0.