### PR TITLE
Migrate to Pydantic v2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.8
 install_requires =
     multiprocessing-logging == 0.3.1
     psycopg2
-    pydantic >=1.0.0,<2.0.0
+    pydantic >= 2.0.0
     pyzabbix
     requests
     tomli

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ import logging
 import tomli
 
 import pytest
-from pydantic import Extra, ValidationError
+from pydantic import ValidationError
 import zabbix_auto_config.models as models
 
 
@@ -30,7 +30,7 @@ def test_config_extra_field_allowed(
     # Allow extra fields for this test
     original_extra = models.Settings.model_config["extra"]
     try:
-        models.Settings.model_config["extra"] = Extra.allow
+        models.Settings.model_config["extra"] = "allow"
         models.Settings(**config)
         assert len(caplog.records) == 0
     finally:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,13 +28,13 @@ def test_config_extra_field_allowed(
     config["foo"] = "bar"
 
     # Allow extra fields for this test
-    original_extra = models.Settings.__config__.extra
+    original_extra = models.Settings.model_config["extra"]
     try:
-        models.Settings.__config__.extra = Extra.allow
+        models.Settings.model_config["extra"] = Extra.allow
         models.Settings(**config)
         assert len(caplog.records) == 0
     finally:
-        models.Settings.__config__.extra = original_extra
+        models.Settings.model_config["extra"] = original_extra
 
 
 def test_sourcecollectorsettings_defaults():
@@ -104,7 +104,6 @@ def test_sourcecollectorsettings_duration_too_short():
     errors = exc_info.value.errors()
     assert len(errors) == 1
     error = errors[0]
-    assert error["loc"] == ("error_duration",)
     assert "greater than 300" in error["msg"]
     assert error["type"] == "value_error"
 
@@ -122,4 +121,4 @@ def test_sourcecollectorsettings_duration_negative():
     assert len(errors) == 1
     error = errors[0]
     assert error["loc"] == ("error_duration",)
-    assert error["type"] == "value_error.number.not_ge"
+    assert error["type"] == "greater_than_equal"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,11 @@ from pydantic import ValidationError
 from zabbix_auto_config import models
 
 
+# NOTE: Do not test msg and ctx of Pydantic errors!
+# They are not guaranteed to be stable between minor versions.
+# https://docs.pydantic.dev/latest/version-compatibility/#pydantic-v2-changes
+
+
 def find_host_by_hostname(hosts, hostname):
     for host in hosts:
         if host["hostname"].startswith(hostname):
@@ -28,7 +33,7 @@ def test_invalid_proxy_pattern(invalid_hosts):
     assert len(errors) == 1
     error = errors[0]
     assert error["loc"] == ("proxy_pattern",)
-    assert error["msg"] == "Assertion failed, Must be valid regexp pattern: '['"
+    assert "Must be valid regexp pattern: '['" in error["msg"]
     assert error["type"] == "assertion_error"
 
 
@@ -40,7 +45,7 @@ def test_invalid_interface(invalid_hosts):
     assert len(errors) == 1
     error = errors[0]
     assert error["loc"] == ("interfaces", 0)
-    assert error["msg"] == "Value error, Interface of type 2 must have details set"
+    assert "Interface of type 2 must have details set" in error["msg"]
     assert error["type"] == "value_error"
 
 
@@ -52,7 +57,7 @@ def test_duplicate_interface(invalid_hosts):
     assert len(errors) == 1
     error = errors[0]
     assert error["loc"] == ("interfaces",)
-    assert error["msg"] == "Assertion failed, No duplicate interface types: [1, 1]"
+    assert "No duplicate interface types: [1, 1]" in error["msg"]
     assert error["type"] == "assertion_error"
 
 
@@ -65,9 +70,7 @@ def test_invalid_importance(invalid_hosts):
     assert len(errors) == 1
     error = errors[0]
     assert error["loc"] == ("importance",)
-    assert error["msg"] == "Input should be greater than or equal to 0"
     assert error["input"] == -1
-    assert error["ctx"] == {"ge": 0}
     assert error["type"] == "greater_than_equal"
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 from zabbix_auto_config import models
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -24,53 +24,51 @@ def test_invalid_proxy_pattern(invalid_hosts):
     host = find_host_by_hostname(invalid_hosts, "invalid-proxy-pattern")
     with pytest.raises(ValidationError) as exc_info:
         models.Host(**host)
-    assert exc_info.value.errors() == [
-        {
-            "loc": ("proxy_pattern",),
-            "msg": "Must be valid regexp pattern: '['",
-            "type": "assertion_error",
-        }
-    ]
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["loc"] == ("proxy_pattern",)
+    assert error["msg"] == "Assertion failed, Must be valid regexp pattern: '['"
+    assert error["type"] == "assertion_error"
 
 
 def test_invalid_interface(invalid_hosts):
     host = find_host_by_hostname(invalid_hosts, "invalid-interface")
     with pytest.raises(ValidationError) as exc_info:
         models.Host(**host)
-    assert exc_info.value.errors() == [
-        {
-            "loc": ("interfaces", 0, "type"),
-            "msg": "Interface of type 2 must have details set",
-            "type": "value_error",
-        }
-    ]
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["loc"] == ("interfaces", 0)
+    assert error["msg"] == "Value error, Interface of type 2 must have details set"
+    assert error["type"] == "value_error"
 
 
 def test_duplicate_interface(invalid_hosts):
     host = find_host_by_hostname(invalid_hosts, "duplicate-interface")
     with pytest.raises(ValidationError) as exc_info:
         models.Host(**host)
-    assert exc_info.value.errors() == [
-        {
-            "loc": ("interfaces",),
-            "msg": "No duplicate interface types: [1, 1]",
-            "type": "assertion_error",
-        }
-    ]
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["loc"] == ("interfaces",)
+    assert error["msg"] == "Assertion failed, No duplicate interface types: [1, 1]"
+    assert error["type"] == "assertion_error"
+
 
 
 def test_invalid_importance(invalid_hosts):
     host = find_host_by_hostname(invalid_hosts, "invalid-importance")
     with pytest.raises(ValidationError) as exc_info:
         models.Host(**host)
-    assert exc_info.value.errors() == [
-        {
-            "loc": ("importance",),
-            "msg": "ensure this value is greater than or equal to 0",
-            "type": "value_error.number.not_ge",
-            "ctx": {"limit_value": 0},
-        }
-    ]
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["loc"] == ("importance",)
+    assert error["msg"] == "Input should be greater than or equal to 0"
+    assert error["input"] == -1
+    assert error["ctx"] == {"ge": 0}
+    assert error["type"] == "greater_than_equal"
 
 
 

--- a/tests/test_processing/test_sourcecollectorprocess.py
+++ b/tests/test_processing/test_sourcecollectorprocess.py
@@ -64,7 +64,7 @@ def test_source_collector_disable_on_failure():
         module=FaultySourceCollector,
         config=SourceCollectorSettings(
             module_name="faulty_source_collector",
-            update_interval=0.1,
+            update_interval=1,
             disable_duration=3600,
             exit_on_error=False,
             error_duration=10,
@@ -77,7 +77,7 @@ def test_source_collector_disable_on_failure():
     # if we terminate the process before it has the chance to
     # set state["ok"] to False, the test will fail.
     process.start()
-    time.sleep(0.5)  # wait for process to start
+    time.sleep(1.5)  # wait for process to start
     process.stop_event.set()
     process.join(timeout=0.5)
 

--- a/zabbix_auto_config/__init__.py
+++ b/zabbix_auto_config/__init__.py
@@ -120,9 +120,6 @@ def main():
     multiprocessing_logging.install_mp_handler()
     logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
 
-    if config.zac.health_file is not None:
-        health_file = os.path.abspath(config.zac.health_file)
-
     logging.info("Main start (%d) version %s", os.getpid(), __version__)
 
     stop_event = multiprocessing.Event()
@@ -165,8 +162,13 @@ def main():
 
         while not stop_event.is_set():
             if next_status < datetime.datetime.now():
-                if health_file is not None:
-                    write_health(health_file, processes, source_hosts_queues, config.zabbix.failsafe)
+                if config.zac.health_file is not None:
+                    write_health(
+                        config.zac.health_file,
+                        processes,
+                        source_hosts_queues,
+                        config.zabbix.failsafe,
+                    )
                 log_process_status(processes)
                 next_status = datetime.datetime.now() + datetime.timedelta(seconds=status_interval)
 

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -1,27 +1,13 @@
 import logging
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-)
-
-from pydantic import (
-    field_validator,
-    model_validator,
-    ConfigDict,
-    BaseModel,
-    BaseModel as PydanticBaseModel,
-    Field,
-)
+from pydantic import BaseModel
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Annotated
 
 from . import utils
-from typing_extensions import Annotated
 
 # TODO: Models aren't validated when making changes to a set/list. Why? How to handle?
 

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -18,8 +18,6 @@ from pydantic import (
     BaseModel,
     BaseModel as PydanticBaseModel,
     Field,
-    validator,
-    Extra,
 )
 
 from . import utils
@@ -28,7 +26,7 @@ from typing_extensions import Annotated
 # TODO: Models aren't validated when making changes to a set/list. Why? How to handle?
 
 
-class ConfigBaseModel(PydanticBaseModel, extra=Extra.ignore):
+class ConfigBaseModel(PydanticBaseModel, extra="ignore"):
     """Base class for all config models. Warns if unknown fields are passed in."""
     # https://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally
 
@@ -38,7 +36,7 @@ class ConfigBaseModel(PydanticBaseModel, extra=Extra.ignore):
         """Checks for unknown fields and logs a warning if any are found.
         Does not log warnings if extra is set to `Extra.allow`.
         """
-        if cls.model_config["extra"] == Extra.allow:
+        if cls.model_config["extra"] == "allow":
             return values
         for key in values:
             if key not in cls.model_fields:
@@ -83,7 +81,7 @@ class ZacSettings(ConfigBaseModel):
     health_file: Optional[Path] = None
 
 
-class SourceCollectorSettings(ConfigBaseModel, extra=Extra.allow):
+class SourceCollectorSettings(ConfigBaseModel, extra="allow"):
     module_name: str
     update_interval: int
     error_tolerance: int = Field(

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -144,7 +144,7 @@ class Host(BaseModel):
     siteadmins: Set[str] = set()
     sources: Set[str] = set()
     tags: Set[Tuple[str, str]] = set()
-    model_config = ConfigDict(validate_assignment=True)
+    model_config = ConfigDict(validate_assignment=True, revalidate_instances="always")
 
     @model_validator(mode="before")
     @classmethod

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -266,13 +266,14 @@ class SourceHandlerProcess(BaseProcess):
                 # logging.debug(f"Replaced host <{host['hostname']}> from source <{source}>")
                 cursor.execute(
                     f"UPDATE {self.db_source_table} SET data = %s WHERE data->>'hostname' = %s AND data->'sources' ? %s",
-                    [host.json(), host.hostname, source],
+                    [host.model_dump_json(), host.hostname, source],
                 )
                 return HostAction.UPDATE
         else:
             # logging.debug(f"Inserted host <{host['hostname']}> from source <{source}>")
             cursor.execute(
-                f"INSERT INTO {self.db_source_table} (data) VALUES (%s)", [host.json()]
+                f"INSERT INTO {self.db_source_table} (data) VALUES (%s)",
+                [host.model_dump_json()],
             )
             return HostAction.INSERT
 
@@ -440,13 +441,14 @@ class SourceMergerProcess(BaseProcess):
                 # logging.debug(f"Replaced host <{host['hostname']}> from source <{source}>")
                 cursor.execute(
                     f"UPDATE {self.db_hosts_table} SET data = %s WHERE data->>'hostname' = %s",
-                    [host.json(), host.hostname],
+                    [host.model_dump_json(), host.hostname],
                 )
                 return HostAction.UPDATE
         else:
             # logging.debug(f"Inserted host <{host['hostname']}> from source <{source}>")
             cursor.execute(
-                f"INSERT INTO {self.db_hosts_table} (data) VALUES (%s)", [host.json()]
+                f"INSERT INTO {self.db_hosts_table} (data) VALUES (%s)",
+                [host.model_dump_json()],
             )
             return HostAction.INSERT
 

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -409,14 +409,17 @@ class SourceMergerProcess(BaseProcess):
 
         for host_modifier in self.host_modifiers:
             try:
-                modified_host = host_modifier["module"].modify(host.copy(deep=True))
+                modified_host = host_modifier["module"].modify(
+                    host.model_copy(deep=True)
+                )
                 assert isinstance(
                     modified_host, models.Host
                 ), f"Modifier returned invalid type: {type(modified_host)}"
                 assert (
                     host.hostname == modified_host.hostname
                 ), f"Modifier changed the hostname, '{host.hostname}' -> '{modified_host.hostname}'"
-                host = modified_host
+                # Re-validate the host after modification
+                host = host.model_validate(modified_host)
             except AssertionError as e:
                 logging.warning(
                     "Host, '%s', was modified to be invalid by modifier: '%s'. Error: %s",


### PR DESCRIPTION
Pydantic v2 brings with it [much higher performance](https://docs.pydantic.dev/latest/blog/pydantic-v2-alpha/#headlines) (5-50x times faster than Pydantic v1), as well as improved APIs for validation and (de)serialization.

This PR bumps the minimum Pydantic version of ZAC to 2.0.0.  Code changes have been made to accommodate the new APIs introduced in 2.0.0. Most of the code changes were made using the migration tool [Bump Pydantic](https://github.com/pydantic/bump-pydantic) as outlined in the [Pydantic V2 Migration Guide](https://docs.pydantic.dev/latest/migration/). 

The use of `BaseSettings` has been substituted with `BaseModel` since we didn't use any of the features offered by `BaseSettings`. Furthermore, the `BaseSettings` class has been moved to the [pydantic-settings](https://github.com/pydantic/pydantic-settings) package, which we shouldn't include if we don't need to.

