### PR TITLE
Add template group creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Zabbix-auto-config is an utility that aims to automatically configure hosts, host groups, host inventories, template groups and templates in the monitoring software [Zabbix](https://www.zabbix.com/).
 
-Note: This is only tested with Zabbix 5.0 LTS.
+Note: Only tested with Zabbix 6.0 and 6.4.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-Zabbix-auto-config is an utility that aims to automatically configure hosts, host groups, host inventories and templates in the monitoring software [Zabbix](https://www.zabbix.com/).
+Zabbix-auto-config is an utility that aims to automatically configure hosts, host groups, host inventories, template groups and templates in the monitoring software [Zabbix](https://www.zabbix.com/).
 
 Note: This is only tested with Zabbix 5.0 LTS.
 
@@ -101,7 +101,7 @@ def collect(*args: Any, **kwargs: Any) -> List[Host]:
 
 if __name__ == "__main__":
     for host in collect():
-        print(host.json())
+        print(host.model_dump_json())
 EOF
 cat > path/to/host_modifier_dir/mod.py << EOF
 from zabbix_auto_config.models import Host

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -55,7 +55,8 @@ hostgroup_disabled = "All-auto-disabled-hosts"
 hostgroup_source_prefix = "Source-"
 hostgroup_importance_prefix = "Importance-"
 
-# Template group creation (Zabbix >=6.4 only)
+# Template group creation
+# NOTE: will create host groups if enabled on Zabbix <6.4
 create_templategroups = true
 templategroup_prefix = "Templates-"
 

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -55,7 +55,7 @@ managed_inventory = ["location"]
 #hostgroup_source_prefix = "Source-"
 #hostgroup_importance_prefix = "Importance-"
 #extra_siteadmin_hostgroup_prefixes = []
-templategroup_prefix = "Templates-"
+#templategroup_prefix = "Templates-"
 
 [source_collectors.mysource]
 # Name of the source collector module without the .py extension

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -55,6 +55,7 @@ managed_inventory = ["location"]
 #hostgroup_source_prefix = "Source-"
 #hostgroup_importance_prefix = "Importance-"
 #extra_siteadmin_hostgroup_prefixes = []
+templategroup_prefix = "Templates-"
 
 [source_collectors.mysource]
 # Name of the source collector module without the .py extension

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -49,13 +49,17 @@ tags_prefix = "zac_"
 managed_inventory = ["location"]
 
 # Names of hostgroups that zabbix-auto-config will manage.
-#hostgroup_all = "All-hosts"
-#hostgroup_manual = "All-manual-hosts"
-#hostgroup_disabled = "All-auto-disabled-hosts"
-#hostgroup_source_prefix = "Source-"
-#hostgroup_importance_prefix = "Importance-"
-#extra_siteadmin_hostgroup_prefixes = []
-#templategroup_prefix = "Templates-"
+hostgroup_all = "All-hosts"
+hostgroup_manual = "All-manual-hosts"
+hostgroup_disabled = "All-auto-disabled-hosts"
+hostgroup_source_prefix = "Source-"
+hostgroup_importance_prefix = "Importance-"
+
+# Template group creation (Zabbix >=6.4 only)
+create_templategroups = true
+templategroup_prefix = "Templates-"
+
+extra_siteadmin_hostgroup_prefixes = []
 
 [source_collectors.mysource]
 # Name of the source collector module without the .py extension
@@ -88,5 +92,5 @@ another_kwarg = "value2"         # We can pass an arbitrary number of kwargs to 
 module_name = "mysource"
 update_interval = 60
 error_tolerance = 0      # no tolerance for errors (default)
-exit_on_error = true     # exit application if source fails
+exit_on_error = true     # exit application if source fails (default)
 source = "other"         # extra kwarg used in mysource module

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -56,7 +56,7 @@ hostgroup_source_prefix = "Source-"
 hostgroup_importance_prefix = "Importance-"
 
 # Template group creation
-# NOTE: will create host groups if enabled on Zabbix <6.4
+# NOTE: will create host groups if enabled on Zabbix <6.2
 create_templategroups = true
 templategroup_prefix = "Templates-"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pyzabbix>=1.3.0",
     "requests>=1.0.0",
     "tomli>=2.0.0",
-    "packaging>=24.0",
+    "packaging>=23.2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pyzabbix>=1.3.0",
     "requests>=1.0.0",
     "tomli>=2.0.0",
+    "packaging>=24.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 import pytest
 from pydantic import ValidationError
+
 from zabbix_auto_config import models
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,6 @@ import logging
 from typing import Optional
 import pytest
 from pydantic import ValidationError
-
 from zabbix_auto_config import models
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,40 @@
+"""Santiy testing of Zabbix API version parsing. 
+
+Tests against known versions of Zabbix. Expects support for alpha, beta and rc.
+"""
+
+from typing import Tuple
+from packaging.version import Version
+import pytest
+
+
+@pytest.mark.parametrize(
+    "version, release",
+    [
+        # Certain major versions released in 2023
+        ("7.0.0", (7, 0, 0)),
+        ("6.4.8", (6, 4, 8)),
+        ("6.0.23", (6, 0, 23)),
+        ("5.0.39", (5, 0, 39)),
+        ("6.2.9", (6, 2, 9)),
+        # Pre-release versions
+        ("7.0.0alpha7", (7, 0, 0)),
+        ("7.0.0a7", (7, 0, 0)),  # short form
+        ("6.4.0beta6", (6, 4, 0)),
+        ("6.4.0b6", (6, 4, 0)),  # short form
+        ("6.4.8rc1", (6, 4, 8)),
+    ],
+)
+def test_version(version: str, release: Tuple[int, int, int]):
+    """Test that the version string is parsed correctly."""
+    v = Version(version)
+    assert v.release == release
+    assert v.major == release[0]
+    assert v.minor == release[1]
+    assert v.micro == release[2]
+
+    # Test comparison
+    assert v.release < (999, 999, 999)
+    assert v.release > (0, 0, 0)
+    assert v > Version("0.0.0")
+    assert v < Version("999.999.999")

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from pydantic import BaseModel, ValidationInfo
 from pydantic import BaseModel as PydanticBaseModel
@@ -283,30 +283,6 @@ class Host(BaseModel):
             self.proxy_pattern = sorted(list(proxy_patterns))[0]
         elif len(proxy_patterns) == 1:
             self.proxy_pattern = proxy_patterns.pop()
-
-
-class ZabbixVersion(NamedTuple):
-    major: int
-    minor: int
-    patch: int
-
-    def __str__(self) -> str:
-        return f"{self.major}.{self.minor}.{self.patch}"
-
-    @classmethod
-    def from_version_string(cls, version_string: str) -> ZabbixVersion:
-        """Constructs a ZabbixVersion from a semantic version string from the API.
-        
-        See: <https://www.zabbix.com/documentation/current/en/manual/api/reference/apiinfo/version>
-        """
-        parts = version_string.split(".")
-        if len(parts) != 3:
-            raise ValueError(f"Cannot parse Zabbix version string: {version_string}")
-        return cls(
-            major=int(parts[0]),
-            minor=int(parts[1]),
-            patch=int(parts[2]),
-        )
 
 
 class HostActions(BaseModel):

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -65,6 +65,8 @@ class ZabbixSettings(ConfigBaseModel):
 
     hostgroup_source_prefix: str = "Source-"
     hostgroup_importance_prefix: str = "Importance-"
+    
+    create_templategroups: bool = True
     templategroup_prefix: str = "Templates-"
 
     # Prefixes for extra host groups to create based on the host groups

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -290,6 +290,10 @@ class ZabbixVersion(NamedTuple):
 
     @classmethod
     def from_version_string(cls, version_string: str) -> ZabbixVersion:
+        """Constructs a ZabbixVersion from a semantic version string from the API.
+        
+        See: <https://www.zabbix.com/documentation/current/en/manual/api/reference/apiinfo/version>
+        """
         parts = version_string.split(".")
         if len(parts) != 3:
             raise ValueError(f"Cannot parse Zabbix version string: {version_string}")

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -66,7 +66,7 @@ class ZabbixSettings(ConfigBaseModel):
     hostgroup_source_prefix: str = "Source-"
     hostgroup_importance_prefix: str = "Importance-"
     
-    create_templategroups: bool = True
+    create_templategroups: bool = False
     templategroup_prefix: str = "Templates-"
 
     # Prefixes for extra host groups to create based on the host groups

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -62,6 +62,7 @@ class ZabbixSettings(ConfigBaseModel):
 
     hostgroup_source_prefix: str = "Source-"
     hostgroup_importance_prefix: str = "Importance-"
+    templategroup_prefix: str = "Templates-"
 
     # Prefixes for extra host groups to create based on the host groups
     # in the siteadmin mapping. 

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -53,7 +53,6 @@ class ZabbixSettings(ConfigBaseModel):
         description="The timeout in seconds for HTTP requests to Zabbix.",
         ge=0,
     )
-    create_templategroups: bool = True
 
     tags_prefix: str = "zac_"
     managed_inventory: List[str] = []

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -290,6 +290,9 @@ class ZabbixVersion(NamedTuple):
     minor: int
     patch: int
 
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
     @classmethod
     def from_version_string(cls, version_string: str) -> ZabbixVersion:
         """Constructs a ZabbixVersion from a semantic version string from the API.

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -1144,7 +1144,11 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
 
         
     def _create_templategroups(self, tgroups: Set[str]) -> None:
-        """Zabbix >=6.2 template group creation method."""
+        """Create the given template groups if they don't exist.
+
+        Args:
+            tgroups: A set of template group names to create.
+        """
         res = self.api.templategroup.get(output=["name", "groupid"])
         existing_tgroups = set(tg["name"] for tg in res)
         for tgroup in tgroups:
@@ -1153,12 +1157,14 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
             self.create_templategroup(tgroup)
 
     def _create_templategroups_pre_62_compat(self, tgroups: Set[str], existing_hostgroups: List[Dict[str, str]]) -> None:
-        """Zabbix <6.2 template group compatibility fallback method.
-        Template groups don't exist in Zabbix <6.2, so we create host
-        groups to fulfill the same purpose.
-        
-        Creates template host groups for all groups in the siteadmin
-        mapping file with the configured template group prefix."""
+        """Compatibility method for creating template groups on Zabbix <6.2.
+
+        Because template groups do not exist in <6.2, we instead create
+        host groups with the given names.
+
+        Args:
+            tgroups: A set of template group names to create.
+        """
         existing_hgroup_names = set(h["name"] for h in existing_hostgroups)
         for tgroup in tgroups:
             if tgroup in existing_hgroup_names:

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -13,7 +13,7 @@ import sys
 import signal
 import itertools
 import queue
-from typing import Dict, List, TYPE_CHECKING, Optional
+from typing import Dict, List, TYPE_CHECKING, Optional, Set
 
 import psycopg2
 from pydantic import ValidationError

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -1146,8 +1146,6 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
         """Zabbix >=6.4 template group creation method."""
         res = self.api.templategroup.get(output=["name", "groupid"])
         existing_tgroups = set(tg["name"] for tg in res)
-
-        # for templategroups in mapping.values():
         for tgroup in tgroups:
             if tgroup in existing_tgroups:
                 continue
@@ -1161,7 +1159,6 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
         Creates template host groups for all groups in the siteadmin
         mapping file with the configured template group prefix."""
         existing_hgroup_names = set(h["name"] for h in existing_hostgroups)
-
         for tgroup in tgroups:
             if tgroup in existing_hgroup_names:
                 continue

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -1085,18 +1085,22 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
             return None
 
     def create_extra_hostgroups(
-        self, managed_hostgroup_names: Set[str], existing_hostgroups: List[Dict[str, str]]
+        self, existing_hostgroups: List[Dict[str, str]]
     ) -> None:
         """Creates additonal host groups based on the prefixes specified
         in the config file. These host groups are not assigned hosts by ZAC."""
         hostgroup_names = set(h["name"] for h in existing_hostgroups)
 
         for prefix in self.config.extra_siteadmin_hostgroup_prefixes:
-            hgroups = [utils.with_prefix(hg, prefix) for hg in managed_hostgroup_names]
-            for hostgroup in hgroups:
-                if hostgroup in hostgroup_names:
-                    continue
-                self.create_hostgroup(hostgroup)
+            mapping = utils.mapping_values_with_prefix(
+                self.siteadmin_hostgroup_map,  # this is copied in the function
+                prefix=prefix,
+            )
+            for hostgroups in mapping.values():
+                for hostgroup in hostgroups:
+                    if hostgroup in hostgroup_names:
+                        continue
+                    self.create_hostgroup(hostgroup)
 
     def create_templategroup(self, templategroup_name: str) -> Optional[str]:
         if self.config.dryrun:
@@ -1168,7 +1172,7 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
 
         # Create extra host groups if necessary
         if self.config.extra_siteadmin_hostgroup_prefixes:
-            self.create_extra_hostgroups(managed_hostgroup_names, existing_hostgroups)
+            self.create_extra_hostgroups(existing_hostgroups)
         
         # Create template groups if enabled
         if self.config.create_templategroups:

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -1075,7 +1075,9 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
         logging.debug("Creating hostgroup: '%s'", hostgroup_name)
         try:
             result = self.api.hostgroup.create(name=hostgroup_name)
-            return result["groupids"][0]
+            groupid = result["groupids"][0]
+            logger.info("Created host group '%s' (%s)", hostgroup_name, groupid)
+            return groupid
         except pyzabbix.ZabbixAPIException as e:
             logging.error(
                 "Error when creating hostgroups '%s': %s", hostgroup_name, e.args
@@ -1108,7 +1110,9 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
         logging.debug("Creating template group: '%s'", templategroup_name)
         try:
             result = self.api.templategroup.create(name=templategroup_name)
-            return result["groupids"][0]
+            groupid = result["groupids"][0]
+            logger.info("Created template group '%s' (%s)", templategroup_name, groupid)
+            return groupid
         except pyzabbix.ZabbixAPIException as e:
             logging.error(
                 "Error when creating template group '%s': %s",

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -1120,7 +1120,11 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
     def create_templategroups(self) -> None:
         """>=6.4 ONLY: Creates template groups for each host group in
         the mapping file."""
-        if self.zabbix_version < (6, 4, 0) or not self.config.create_templategroups:
+        if not self.config.create_templategroups:
+            logger.debug("Skipping template group creation. Feature is disabled.")
+            return
+        elif self.zabbix_version < (6, 4, 0):
+            logger.info("Skipping template group creation. Feature requires Zabbix >= 6.4.0.")
             return
 
         tgroups = self.api.templategroup.get(output=["name", "groupid"])

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -1076,7 +1076,7 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
         try:
             result = self.api.hostgroup.create(name=hostgroup_name)
             groupid = result["groupids"][0]
-            logger.info("Created host group '%s' (%s)", hostgroup_name, groupid)
+            logging.info("Created host group '%s' (%s)", hostgroup_name, groupid)
             return groupid
         except pyzabbix.ZabbixAPIException as e:
             logging.error(
@@ -1111,7 +1111,7 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
         try:
             result = self.api.templategroup.create(name=templategroup_name)
             groupid = result["groupids"][0]
-            logger.info("Created template group '%s' (%s)", templategroup_name, groupid)
+            logging.info("Created template group '%s' (%s)", templategroup_name, groupid)
             return groupid
         except pyzabbix.ZabbixAPIException as e:
             logging.error(
@@ -1125,10 +1125,10 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
         """>=6.4 ONLY: Creates template groups for each host group in
         the mapping file."""
         if not self.config.create_templategroups:
-            logger.debug("Skipping template group creation. Feature is disabled.")
+            logging.debug("Skipping template group creation. Feature is disabled.")
             return
         elif self.zabbix_version < (6, 4, 0):
-            logger.info("Skipping template group creation. Feature requires Zabbix >= 6.4.0.")
+            logging.info("Skipping template group creation. Feature requires Zabbix >= 6.4.0.")
             return
 
         tgroups = self.api.templategroup.get(output=["name", "groupid"])


### PR DESCRIPTION
This PR introduces the ability to automatically create template groups for all managed host groups. Two new configuration options have been introduced to facilitate this:

```toml
[zabbix]
create_templategroups = false
templategroup_prefix = "Templates-"
```

On Zabbix <6.2, this feature will create the template groups as host groups instead.

The feature is disabled by default.

## Version Checks

The `BaseProcess` class now fetches the Zabbix API version ([always matches the Zabbix Server version](https://www.zabbix.com/documentation/current/en/manual/api/reference/apiinfo/version)) on instantiation and stores it in the attribute `self.zabbix_version`, which allows each process to perform version checks without having to add boilerplate code for fetching and parsing version numbers first. The version is stored as a [`packaging.version.Version`](https://packaging.pypa.io/en/latest/version.html#packaging.version.Version) object.

Comparing version numbers should be done on the release portion of the version name against a tuple of major, minor, micro (patch) versions, i.e.:

```py
if self.zabbix_version.release >= (6, 2, 0): ...
```
And not `Version` objects against each other:

```py
if self.zabbix_version >= Version("6.2.0"): ...
```

The main difference is that comparing releases allows for using alpha, beta and rc versions of Zabbix with ZAC. If we compared two `Version` objects against each other, the application would assume certain features are not available when running these pre-release versions:

```pycon
>>> Version("6.2.0alpha1") >= Version("6.2.0") # fails to detect version 6.2
False
>>> Version("6.2.0alpha1").release >= (6, 2, 0) # correctly detects 6.2
True
```


Individual version number components can be accessed via attributes:

```py
if self.zabbix_version.major >= 1: ...
if self.zabbix_version.minor >= 2: ...
if self.zabbix_version.micro >= 3: ...
```