### PR TITLE
Add configurable log level

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -3,6 +3,7 @@ source_collector_dir = "path/to/source_collector_dir/"
 host_modifier_dir = "path/to/host_modifier_dir/"
 db_uri = "dbname='zac' user='zabbix' host='localhost' password='secret' port=5432 connect_timeout=2"
 health_file = "/tmp/zac_health.json"
+log_level = "DEBUG"
 
 [zabbix]
 map_dir = "path/to/map_dir/"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -168,7 +168,7 @@ def test_zacsettings_log_level_serialize() -> None:
     settings = models.ZacSettings(
         db_uri="", source_collector_dir="", host_modifier_dir="", log_level=logging.INFO
     )
-    assert logging.INFO == 20  # sanity check
+    assert settings.log_level == logging.INFO == 20  # sanity check
 
     # Serialize to dict:
     settings_dict = settings.model_dump()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from pydantic import ValidationError
 from zabbix_auto_config import models
@@ -114,3 +115,65 @@ def test_host_merge_invalid(full_hosts):
     h1 = models.Host(**host)
     with pytest.raises(TypeError):
         h1.merge(object())
+
+
+@pytest.mark.parametrize(
+    "level,expect",
+    [
+        ["notset", logging.NOTSET],
+        ["debug", logging.DEBUG],
+        ["info", logging.INFO],
+        ["warn", logging.WARN],
+        ["warning", logging.WARNING],
+        ["error", logging.ERROR],
+        ["fatal", logging.FATAL],
+        ["critical", logging.CRITICAL],
+    ],
+)
+@pytest.mark.parametrize("upper", [True, False])
+def test_zacsettings_log_level_str(level: str, expect: int, upper: bool) -> None:
+    settings = models.ZacSettings(
+        db_uri="",
+        source_collector_dir="",
+        host_modifier_dir="",
+        log_level=level.upper() if upper else level.lower(),
+    )
+    assert settings.log_level == expect
+
+
+@pytest.mark.parametrize(
+    "level,expect",
+    [
+        [0, logging.NOTSET],
+        [10, logging.DEBUG],
+        [20, logging.INFO],
+        [30, logging.WARN],
+        [30, logging.WARNING],
+        [40, logging.ERROR],
+        [50, logging.FATAL],
+        [50, logging.CRITICAL],
+    ],
+)
+def test_zacsettings_log_level_int(level: str, expect: int) -> None:
+    settings = models.ZacSettings(
+        db_uri="",
+        source_collector_dir="",
+        host_modifier_dir="",
+        log_level=level,
+    )
+    assert settings.log_level == expect
+
+
+def test_zacsettings_log_level_serialize() -> None:
+    settings = models.ZacSettings(
+        db_uri="", source_collector_dir="", host_modifier_dir="", log_level=logging.INFO
+    )
+    assert logging.INFO == 20  # sanity check
+
+    # Serialize to dict:
+    settings_dict = settings.model_dump()
+    assert settings_dict["log_level"] == "INFO"
+
+    # Serialize to JSON:
+    settings_json = settings.model_dump_json()
+    assert '"log_level":"INFO"' in settings_json

--- a/zabbix_auto_config/__init__.py
+++ b/zabbix_auto_config/__init__.py
@@ -114,14 +114,13 @@ def log_process_status(processes):
 
 
 def main():
+    multiprocessing_logging.install_mp_handler()
     logging.basicConfig(format='%(asctime)s %(levelname)s [%(processName)s %(process)d] [%(name)s] %(message)s', datefmt="%Y-%m-%dT%H:%M:%S%z", level=logging.DEBUG)
     config = get_config()
-
-    multiprocessing_logging.install_mp_handler()
+    logging.getLogger().setLevel(config.zac.log_level)
     logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
 
     logging.info("Main start (%d) version %s", os.getpid(), __version__)
-
     stop_event = multiprocessing.Event()
     state_manager = multiprocessing.Manager()
     processes = []
@@ -198,3 +197,7 @@ def main():
             alive_processes = [process for process in processes if process.is_alive()]
 
     logging.info("Main exit")
+
+
+if __name__ == "__main__":
+    main()

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -147,12 +147,8 @@ class SourceCollectorProcess(BaseProcess):
             self.error_counter.add(exception=e)
             if self.error_counter.tolerance_exceeded():
                 if self.config.exit_on_error:
-                    logging.critical(
-                        "Error tolerance exceeded. Terminating application."
-                    )
+                    logging.critical("Error tolerance exceeded. Terminating application.")
                     self.stop_event.set()
-                    # TODO: raise exception with message above or just an empty exception?
-                    # or just return?
                 else:
                     self.disable()
 
@@ -324,10 +320,6 @@ class SourceHandlerProcess(BaseProcess):
                 current_host = current_hosts.get(host.hostname)
                 action = self.handle_source_host(db_cursor, host, current_host, source)
                 actions[action] += 1
-                if self.stop_event.is_set():
-                    logging.debug("Told to stop. Breaking")
-                    break
-        # self.db_connection.commit()
 
         logging.info(
             "Done handling hosts from source, '%s', in %.2f seconds. Equal hosts: %d, replaced hosts: %d, inserted hosts: %d, removed hosts: %d. Next update: %s",
@@ -608,13 +600,6 @@ class ZabbixHostUpdater(ZabbixUpdater):
                 logging.info("Disabling host: '%s' (%s)", zabbix_host["host"], zabbix_host["hostid"])
             except pyzabbix.ZabbixAPIException as e:
                 logging.error("Error when disabling host '%s' (%s): %s", zabbix_host["host"], zabbix_host["hostid"], e.args)
-            except IndexError:
-                logging.critical(
-                    "Disabled host group '%s' does not exist in Zabbix. Cannot disable host '%s'",
-                    self.config.hostgroup_disabled,
-                    zabbix_host.get("host"),
-                )
-                self.stop_event.set()
         else:
             logging.info("DRYRUN: Disabling host: '%s' (%s)", zabbix_host["host"], zabbix_host["hostid"])
 
@@ -643,13 +628,6 @@ class ZabbixHostUpdater(ZabbixUpdater):
                     logging.info("Enabling new host: '%s' (%s)", hostname, result["hostids"][0])
             except pyzabbix.ZabbixAPIException as e:
                 logging.error("Error when enabling/creating host '%s': %s", hostname, e.args)
-            except IndexError:
-                logging.critical(
-                    "Enabled host group '%s' does not exist in Zabbix. Cannot enable host '%s'",
-                    self.config.hostgroup_all,
-                    hostname,
-                )
-                self.stop_event.set()
         else:
             logging.info("DRYRUN: Enabling host: '%s'", hostname)
 
@@ -767,7 +745,6 @@ class ZabbixHostUpdater(ZabbixUpdater):
 
         if len(hostnames_to_remove) > self.config.failsafe or len(hostnames_to_add) > self.config.failsafe:
             logging.warning("Too many hosts to change (failsafe=%d). Remove: %d, Add: %d. Aborting", self.config.failsafe, len(hostnames_to_remove), len(hostnames_to_add))
-            # TODO: Don't abort here when running in dry run mode
             raise exceptions.ZACException("Failsafe triggered")
 
         for hostname in hostnames_to_remove:

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -20,6 +20,7 @@ from pydantic import ValidationError
 import pyzabbix
 import requests.exceptions
 
+
 from . import exceptions
 from . import models
 from . import utils


### PR DESCRIPTION
This PR adds the ability to control the log level with the new config option `zac.log_level`:

```toml
[zac]
log_level = "DEBUG
```

While the log level technically can be specified as an integer (0, 10 ,20, etc.) it's not recommended.

## Fixes

This PR also fixes the problem of multiprocessing_logging causing an incredibly long traceback whenever the application is terminated, by calling `multiprocessing_logging.install_mp_handler()` _before_ the logger is configured.