### PR TITLE
Add Zabbix API timeout

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -12,6 +12,7 @@ username = "Admin"
 password = "zabbix"
 dryrun = true
 failsafe = 20
+timeout = 60                     # Zabbix API timeout in seconds
 tags_prefix = "zac_"
 managed_inventory = ["location"]
 

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -12,7 +12,7 @@ username = "Admin"
 password = "zabbix"
 dryrun = true
 failsafe = 20
-timeout = 60                     # Zabbix API timeout in seconds
+timeout = 60                     # Zabbix API timeout in seconds (0 = no timeout)
 tags_prefix = "zac_"
 managed_inventory = ["location"]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,3 +42,4 @@ console_scripts =
 test =
     pytest
     hypothesis
+    pytest-timeout

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 import pytest
 from pydantic import ValidationError
 from zabbix_auto_config import models
@@ -177,3 +178,33 @@ def test_zacsettings_log_level_serialize() -> None:
     # Serialize to JSON:
     settings_json = settings.model_dump_json()
     assert '"log_level":"INFO"' in settings_json
+
+@pytest.mark.parametrize(
+        "timeout,expect",
+        [
+            (1, 1),
+            (60, 60),
+            (1234, 1234),
+            (0, None),
+            pytest.param(
+                -1,
+                None,
+                marks=pytest.mark.xfail(
+                    reason="Timeout must be 0 or greater.",
+                    strict=True,
+                    raises=ValidationError,
+                ),
+                id="-1"
+            )
+        ]
+)
+def test_zabbix_settings_timeout(timeout: int, expect: Optional[int]) -> None:
+    settings = models.ZabbixSettings(
+        map_dir="",
+        url="",
+        username="",
+        password="",
+        dryrun=False,
+        timeout=timeout,
+    )
+    assert settings.timeout == expect

--- a/tests/test_processing/test_zabbixupdater.py
+++ b/tests/test_processing/test_zabbixupdater.py
@@ -1,0 +1,83 @@
+import multiprocessing
+from pathlib import Path
+import time
+from unittest.mock import MagicMock, patch, Mock
+import pytest
+import requests
+from zabbix_auto_config import exceptions
+
+from zabbix_auto_config.models import ZabbixSettings
+from zabbix_auto_config.processing import ZabbixUpdater
+
+
+def raises_connect_timeout(*args, **kwargs):
+    raise requests.exceptions.ConnectTimeout("connect timeout")
+
+
+@pytest.mark.timeout(10)
+@patch("psycopg2.connect", MagicMock())  # throwaway mock
+def test_zabbixupdater_connect_timeout():
+    with pytest.raises(exceptions.ZACException) as exc_info:
+        with patch(
+            "pyzabbix.ZabbixAPI.login", new_callable=lambda: raises_connect_timeout
+        ):
+            ZabbixUpdater(
+                name="connect-timeout",
+                db_uri="",
+                state=multiprocessing.Manager().dict(),
+                zabbix_config=ZabbixSettings(
+                    map_dir="",
+                    url="",
+                    username="",
+                    password="",
+                    dryrun=False,
+                    timeout=1,
+                ),
+            )
+    assert "connect timeout" in exc_info.exconly()
+
+
+class TimeoutUpdater(ZabbixUpdater):
+    def do_update(self):
+        raise requests.exceptions.ReadTimeout("read timeout")
+
+
+class PickableMock(MagicMock):
+    def __reduce__(self):
+        return (MagicMock, ())
+
+
+@pytest.mark.timeout(5)
+@patch("psycopg2.connect", PickableMock())
+@patch("pyzabbix.ZabbixAPI", PickableMock())
+def test_zabbixupdater_read_timeout(tmp_path: Path):
+    # TODO: use mapping file fixtures from #67
+    map_dir = tmp_path / "maps"
+    map_dir.mkdir()
+    (map_dir / "property_template_map.txt").touch()
+    (map_dir / "property_hostgroup_map.txt").touch()
+    (map_dir / "siteadmin_hostgroup_map.txt").touch()
+
+    process = TimeoutUpdater(
+        name="read-timeout",
+        db_uri="",
+        state=multiprocessing.Manager().dict(),
+        zabbix_config=ZabbixSettings(
+            map_dir=str(map_dir),
+            url="",
+            username="",
+            password="",
+            dryrun=False,
+            timeout=1,
+        ),
+    )
+
+    # Start the process and wait for it to be marked as unhealthy
+    try:
+        process.start()
+        while process.state["ok"] is True:
+            time.sleep(0.1)
+        assert process.state["ok"] is False
+        process.stop_event.set()
+    finally:
+        process.join(timeout=0.01)

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -46,6 +46,10 @@ class ZabbixSettings(ConfigBaseModel):
     username: str
     password: str
     dryrun: bool
+    timeout: int = Field(
+        60,
+        description="The timeout in seconds for HTTP requests to Zabbix.",
+    )
 
     tags_prefix: str = "zac_"
     managed_inventory: List[str] = []

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -46,9 +46,10 @@ class ZabbixSettings(ConfigBaseModel):
     username: str
     password: str
     dryrun: bool
-    timeout: int = Field(
+    timeout: Optional[int] = Field(
         60,
         description="The timeout in seconds for HTTP requests to Zabbix.",
+        ge=0,
     )
 
     tags_prefix: str = "zac_"
@@ -70,6 +71,12 @@ class ZabbixSettings(ConfigBaseModel):
     # These groups are not managed by ZAC beyond creating them.
     extra_siteadmin_hostgroup_prefixes: Set[str] = set()
 
+    @field_validator("timeout")
+    @classmethod
+    def _validate_timeout(cls, v: Optional[int]) -> Optional[int]:
+        if v == 0:
+            return None
+        return v
 
 class ZacSettings(ConfigBaseModel):
     source_collector_dir: str


### PR DESCRIPTION
This PR adds configurable timeouts for connecting and reading from the Zabbix API. This prevents the application from hanging from waiting indefinitely on HTTP requests that will never be answered by the API.

## Config

A new config option has been added to the `[zabbix]` table:

```toml
[zabbix]
timeout = 60
```

By default, the timeout is set to 60 seconds, but can be disabled by setting it to 0:

```toml
[zabbix]
timeout = 0
```

## Dependencies

A new dev dependency [`pytest-timeout`](https://pypi.org/project/pytest-timeout/) has been added to facilitate testing of subprocesses. Its fixture `pytest.mark.timeout` simplifies termination of processes with no set end duration. It allows us to easily wait for certain conditions in the processes without fear of looping forever if the condition is not hit.

