### PR TITLE
Handle missing required host groups

### DIFF
--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -623,6 +623,13 @@ class ZabbixHostUpdater(ZabbixUpdater):
                 logging.info("Disabling host: '%s' (%s)", zabbix_host["host"], zabbix_host["hostid"])
             except pyzabbix.ZabbixAPIException as e:
                 logging.error("Error when disabling host '%s' (%s): %s", zabbix_host["host"], zabbix_host["hostid"], e.args)
+            except IndexError:
+                logging.critical(
+                    "Disabled host group '%s' does not exist in Zabbix. Cannot disable host '%s'",
+                    self.config.hostgroup_disabled,
+                    zabbix_host.get("host"),
+                )
+                self.stop_event.set()
         else:
             logging.info("DRYRUN: Disabling host: '%s' (%s)", zabbix_host["host"], zabbix_host["hostid"])
 
@@ -651,6 +658,13 @@ class ZabbixHostUpdater(ZabbixUpdater):
                     logging.info("Enabling new host: '%s' (%s)", hostname, result["hostids"][0])
             except pyzabbix.ZabbixAPIException as e:
                 logging.error("Error when enabling/creating host '%s': %s", hostname, e.args)
+            except IndexError:
+                logging.critical(
+                    "Enabled host group '%s' does not exist in Zabbix. Cannot enable host '%s'",
+                    self.config.hostgroup_all,
+                    hostname,
+                )
+                self.stop_event.set()
         else:
             logging.info("DRYRUN: Enabling host: '%s'", hostname)
 


### PR DESCRIPTION
This PR adds exception handling and subsequent termination when the two required host groups are missing. Previously this caused an unhandled `IndexError` exception due to the `ZabbixAPI.hostgroup.get` call returning an empty list.

### Missing disabled host group

```
2023-11-22T11:09:52+0000 CRITICAL [zabbix-host-updater 21006] [root] Disabled host group 'All-auto-disabled-hosts' does not exist in Zabbix. Cannot disable host 'foo.example.com'.
2023-11-22T11:09:52+0000 DEBUG [zabbix-host-updater 21006] [root] Told to stop. Breaking
```

### Missing enabled host group

```
2023-11-22T11:25:38+0000 CRITICAL [zabbix-host-updater 22867] [root] Enabled host group 'All-hosts' does not exist in Zabbix. Cannot enable host 'foo.example.com'
2023-11-22T11:25:38+0000 DEBUG [zabbix-host-updater 22867] [root] Told to stop. Breaking
```
