### PR TITLE
Write failsafe hosts to file

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -2,8 +2,9 @@
 source_collector_dir = "path/to/source_collector_dir/"
 host_modifier_dir = "path/to/host_modifier_dir/"
 db_uri = "dbname='zac' user='zabbix' host='localhost' password='secret' port=5432 connect_timeout=2"
-health_file = "/tmp/zac_health.json"
 log_level = "DEBUG"
+health_file = "/tmp/zac_health.json"
+failsafe_file = "/tmp/zac_failsafe.json"
 
 [zabbix]
 map_dir = "path/to/map_dir/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "multiprocessing-logging==0.3.1",
     "psycopg2>=2.9.5",
-    "pydantic>=2.0.0",
+    "pydantic>=2.6.0",
     "pyzabbix>=1.3.0",
     "requests>=1.0.0",
     "tomli>=2.0.0",

--- a/zabbix_auto_config/__init__.py
+++ b/zabbix_auto_config/__init__.py
@@ -164,7 +164,7 @@ def main():
             "zabbix-host-updater",
             state_manager.State(),
             config.zac.db_uri,
-            config.zabbix,
+            config,
         )
         processes.append(process)
 
@@ -172,7 +172,7 @@ def main():
             "zabbix-hostgroup-updater",
             state_manager.State(),
             config.zac.db_uri,
-            config.zabbix,
+            config,
         )
         processes.append(process)
 
@@ -180,7 +180,7 @@ def main():
             "zabbix-template-updater",
             state_manager.State(),
             config.zac.db_uri,
-            config.zabbix,
+            config,
         )
         processes.append(process)
     except exceptions.ZACException as e:

--- a/zabbix_auto_config/utils.py
+++ b/zabbix_auto_config/utils.py
@@ -8,6 +8,7 @@ import queue
 import re
 from typing import Dict, Iterable, List, Mapping, MutableMapping, Set, Tuple, Union
 
+
 def is_valid_regexp(pattern: str):
     try:
         re.compile(pattern)
@@ -166,3 +167,33 @@ def drain_queue(q: multiprocessing.Queue) -> None:
 def timedelta_to_str(td: datetime.timedelta) -> str:
     """Converts a timedelta to a string of the form HH:MM:SS."""
     return str(td).partition(".")[0]
+
+
+def write_file(path: Union[str, Path], content: str) -> None:
+    """Writes `content` to `path`. Ensures content ends with a newline."""
+    path = Path(path)
+    # Ensure parent dirs exist
+    make_parent_dirs(path)
+
+    try:
+        with open(path, "w") as f:
+            if not content.endswith("\n"):
+                content += "\n"
+            f.write(content)
+    except OSError as e:
+        logging.error("Failed to write to file '%s': %s", path, e)
+        raise
+
+
+def make_parent_dirs(path: Union[str, Path]) -> Path:
+    """Attempts to create all parent directories given a path.
+
+    NOTE: Intended for usage with Pydantic models, and as such it will raise
+    a ValueError instead of OSError if the directory cannot be created."""
+    path = Path(path)
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        raise ValueError(f"Failed to create parent directories for {path}: {e}") from e
+    return path


### PR DESCRIPTION
When the failsafe is hit, we need some way to inspect the hosts that are to be added/removed. This PR makes the application dump the hostnames to add and remove to a JSON file in a  user-configuration location with the option `zac.failsafe_file`.

The JSON file has the following structure:

```json
{
  "add": [
    "host1.example.com",
    "host2.example.com",
  ],
  "remove": [
    "host3.example.com",
    "host4.example.com"
  ]
}
```