### PR TITLE
Approve failsafe with temp file

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -3,8 +3,13 @@ source_collector_dir = "path/to/source_collector_dir/"
 host_modifier_dir = "path/to/host_modifier_dir/"
 db_uri = "dbname='zac' user='zabbix' host='localhost' password='secret' port=5432 connect_timeout=2"
 log_level = "DEBUG"
+# Health status for each ZAC process.
 health_file = "/tmp/zac_health.json"
+# File containing hostnames of hosts to add/remove when failsafe is reached.
 failsafe_file = "/tmp/zac_failsafe.json"
+# File to signal manual approval of adding/removing hosts when failsafe is reached.
+# The file is automatically removed after changes are made.
+failsafe_ok_file = "/tmp/zac_failsafe_ok"
 
 [zabbix]
 map_dir = "path/to/map_dir/"

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -82,11 +82,12 @@ class ZacSettings(ConfigBaseModel):
     source_collector_dir: str
     host_modifier_dir: str
     db_uri: str
-    health_file: Optional[Path] = None
     log_level: int = Field(logging.DEBUG, description="The log level to use.")
+    health_file: Optional[Path] = None
     failsafe_file: Optional[Path] = None
+    failsafe_ok_file: Optional[Path] = None
 
-    @field_validator("failsafe_file", "health_file", mode="after")
+    @field_validator("health_file", "failsafe_file", "failsafe_ok_file", mode="after")
     @classmethod
     def _validate_file_path(cls, v: Optional[Path], info: ValidationInfo) -> Optional[Path]:
         if v is None:

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -740,7 +740,6 @@ class ZabbixHostUpdater(ZabbixUpdater):
         Otherwise, it will write the list of hosts to add and remove to a failsafe file and
         raise a ZACException."""
         if self._check_failsafe_ok_file():
-            logging.info("Failsafe OK file exists. Proceeding with changes.")
             return
         self.write_failsafe_hosts(to_add, to_remove)
         logging.warning(
@@ -780,6 +779,7 @@ class ZabbixHostUpdater(ZabbixUpdater):
                 "Failsafe cannot be approved. Unable to delete failsafe OK file: %s", e
             )
             return False
+        logging.info("Failsafe OK file exists. Proceeding with changes.")
         return True
 
     def do_update(self):

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -776,7 +776,9 @@ class ZabbixHostUpdater(ZabbixUpdater):
         try:
             self.settings.zac.failsafe_ok_file.unlink()
         except OSError as e:
-            logging.error("Unable to delete failsafe OK file: %s", e)
+            logging.error(
+                "Failsafe cannot be approved. Unable to delete failsafe OK file: %s", e
+            )
             return False
         return True
 

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -739,10 +739,9 @@ class ZabbixHostUpdater(ZabbixUpdater):
         If a failsafe OK file exists, the method will remove it and proceed with the changes.
         Otherwise, it will write the list of hosts to add and remove to a failsafe file and
         raise a ZACException."""
-        if self.settings.zac.failsafe_ok_file:
-            if self._check_failsafe_ok_file():
-                logging.info("Failsafe OK file exists. Proceeding with changes.")
-                return
+        if self._check_failsafe_ok_file():
+            logging.info("Failsafe OK file exists. Proceeding with changes.")
+            return
         self.write_failsafe_hosts(to_add, to_remove)
         logging.warning(
             "Too many hosts to change (failsafe=%d). Remove: %d, Add: %d. Aborting",
@@ -769,6 +768,10 @@ class ZabbixHostUpdater(ZabbixUpdater):
         if not self.settings.zac.failsafe_ok_file:
             return False
         if not self.settings.zac.failsafe_ok_file.exists():
+            logging.info(
+                "Failsafe OK file %s does not exist. Create it to approve changes.",
+                self.settings.zac.failsafe_ok_file,
+            )
             return False
         try:
             self.settings.zac.failsafe_ok_file.unlink()


### PR DESCRIPTION
This PR adds the ability to signal approval of changes when the failsafe is hit by creating a temporary file in a location specified by the config option `zac.failsafe_ok_file`. If this file is detected, the application goes ahead and makes the changes. 

The file is always deleted after its detection, so that each approval requires the re-creation of this file. See #73 for more information on the considerations made when implementing this.

Closes #73