### PR TITLE
Add Zabbix 7.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Zabbix-auto-config is an utility that aims to automatically configure hosts, host groups, host inventories, template groups and templates in the monitoring software [Zabbix](https://www.zabbix.com/).
 
-Note: Only tested with Zabbix 6.0 and 6.4.
+Note: Only tested with Zabbix 6.0, 6.4 and 7.0.
 
 ## Requirements
 

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from zabbix_auto_config.failsafe import check_failsafe_ok
+from zabbix_auto_config.failsafe import check_failsafe_ok_file
 from zabbix_auto_config.failsafe import write_failsafe_hosts
 from zabbix_auto_config.models import HostActions
 from zabbix_auto_config.models import Settings
@@ -36,7 +36,7 @@ def failsafe_file(tmp_path: Path) -> Iterable[Path]:
 def test_check_failsafe_ok_file_not_configured(config: Settings) -> None:
     """Test that an unconfigured failsafe OK file always returns False"""
     config.zac.failsafe_ok_file = None
-    assert check_failsafe_ok(config.zac) is False
+    assert check_failsafe_ok_file(config.zac) is False
 
 
 @pytest.mark.parametrize("content", ["", "1"])
@@ -46,7 +46,7 @@ def test_check_failsafe_ok_file_exists(
     """Test that a failsafe ok file that exists is OK with and without content"""
     config.zac.failsafe_ok_file = failsafe_ok_file
     failsafe_ok_file.write_text(content)
-    assert check_failsafe_ok(config.zac) is True
+    assert check_failsafe_ok_file(config.zac) is True
     # Ensure that approving the file also deletes it
     assert failsafe_ok_file.exists() is False
 
@@ -57,7 +57,7 @@ def test_check_failsafe_ok_file_not_exists(
     """Test that a missing failsafe OK file returns False"""
     config.zac.failsafe_file = failsafe_ok_file
     assert failsafe_ok_file.exists() is False
-    assert check_failsafe_ok(config.zac) is False
+    assert check_failsafe_ok_file(config.zac) is False
     assert failsafe_ok_file.exists() is False  # Should still not exist
 
 
@@ -79,9 +79,9 @@ def test_check_failsafe_ok_file_unable_to_delete(
     config.zac.failsafe_ok_file_strict = strict
     # Fails in strict mode - must be able to delete the file
     if strict:
-        assert check_failsafe_ok(config.zac) is False
+        assert check_failsafe_ok_file(config.zac) is False
     else:
-        assert check_failsafe_ok(config.zac) is True
+        assert check_failsafe_ok_file(config.zac) is True
 
 
 @pytest.mark.parametrize(
@@ -136,6 +136,6 @@ def test_write_failsafe_hosts_no_file(
         ["baz.example.com", "qux.example.com"],
     )
     assert (
-        "Unable to write failsafe hosts. No failsafe file configured."
+        "No failsafe file configured, cannot write hosts to add/remove."
         in caplog.messages
     )

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable
+from unittest.mock import MagicMock
+
+import pytest
+
+from zabbix_auto_config.failsafe import check_failsafe_ok
+from zabbix_auto_config.failsafe import write_failsafe_hosts
+from zabbix_auto_config.models import HostActions
+from zabbix_auto_config.models import Settings
+
+
+@pytest.fixture()
+def failsafe_ok_file(tmp_path: Path) -> Iterable[Path]:
+    failsafe_file = tmp_path / "failsafe"
+    try:
+        yield failsafe_file
+    finally:
+        if failsafe_file.exists():
+            failsafe_file.unlink()
+
+
+@pytest.fixture()
+def failsafe_file(tmp_path: Path) -> Iterable[Path]:
+    failsafe_file = tmp_path / "failsafe_hosts.json"
+    try:
+        yield failsafe_file
+    finally:
+        if failsafe_file.exists():
+            failsafe_file.unlink()
+
+
+def test_check_failsafe_ok_file_not_configured(config: Settings) -> None:
+    """Test that an unconfigured failsafe OK file always returns False"""
+    config.zac.failsafe_ok_file = None
+    assert check_failsafe_ok(config.zac) is False
+
+
+@pytest.mark.parametrize("content", ["", "1"])
+def test_check_failsafe_ok_file_exists(
+    failsafe_ok_file: Path, config: Settings, content: str
+) -> None:
+    """Test that a failsafe ok file that exists is OK with and without content"""
+    config.zac.failsafe_ok_file = failsafe_ok_file
+    failsafe_ok_file.write_text(content)
+    assert check_failsafe_ok(config.zac) is True
+    # Ensure that approving the file also deletes it
+    assert failsafe_ok_file.exists() is False
+
+
+def test_check_failsafe_ok_file_not_exists(
+    failsafe_ok_file: Path, config: Settings
+) -> None:
+    """Test that a missing failsafe OK file returns False"""
+    config.zac.failsafe_file = failsafe_ok_file
+    assert failsafe_ok_file.exists() is False
+    assert check_failsafe_ok(config.zac) is False
+    assert failsafe_ok_file.exists() is False  # Should still not exist
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_check_failsafe_ok_file_unable_to_delete(
+    config: Settings, strict: bool
+) -> None:
+    """Test a failsafe OK file we are unable to delete."""
+    # NOTE: it's quite hard to mock a Path file with a real path
+    # so we instead mock the Path object with a MagicMock.
+    # An alternative would be to add a function we can pass Path objects
+    # to for deletion, then mock that function.
+    mock_file = MagicMock(spec=Path)
+    mock_file.exists.return_value = True
+    mock_file.unlink.side_effect = OSError("Unable to delete file")
+
+    assert mock_file.exists() is True
+    config.zac.failsafe_ok_file = mock_file
+    config.zac.failsafe_ok_file_strict = strict
+    # Fails in strict mode - must be able to delete the file
+    if strict:
+        assert check_failsafe_ok(config.zac) is False
+    else:
+        assert check_failsafe_ok(config.zac) is True
+
+
+@pytest.mark.parametrize(
+    "to_add,to_remove",
+    [
+        pytest.param(
+            ["foo.example.com", "bar.example.com"],
+            ["baz.example.com", "qux.example.com"],
+            id="Add and remove",
+        ),
+        pytest.param(["foo.example.com", "bar.example.com"], [], id="Add"),
+        pytest.param([], ["baz.example.com", "qux.example.com"], id="Remove"),
+        pytest.param([], [], id="No changes"),
+    ],
+)
+@pytest.mark.parametrize("failsafe_file_exists", [True, False])
+def test_write_failsafe_hosts(
+    config: Settings,
+    failsafe_file: Path,
+    failsafe_file_exists: bool,
+    to_add: list[str],
+    to_remove: list[str],
+) -> None:
+    """Write a list of hosts to a failsafe file."""
+    # Ensure we handle both file existing and not existing
+    if failsafe_file_exists:
+        failsafe_file.write_text("Contains some data")
+        assert failsafe_file.exists()
+    else:
+        assert not failsafe_file.exists()
+
+    # Assign file and write the hosts
+    config.zac.failsafe_file = failsafe_file
+    write_failsafe_hosts(config.zac, to_add, to_remove)
+
+    # Check contents of file
+    assert failsafe_file.exists()
+    content = failsafe_file.read_text()
+    h = HostActions.model_validate_json(content)
+    assert h == HostActions(add=to_add, remove=to_remove)
+
+
+def test_write_failsafe_hosts_no_file(
+    caplog: pytest.LogCaptureFixture, config: Settings
+) -> None:
+    """Attempt to write failsafe hosts without a failsafe file."""
+    caplog.set_level(logging.WARNING)
+    config.zac.failsafe_file = None
+    write_failsafe_hosts(
+        config.zac,
+        ["foo.example.com", "bar.example.com"],
+        ["baz.example.com", "qux.example.com"],
+    )
+    assert (
+        "Unable to write failsafe hosts. No failsafe file configured."
+        in caplog.messages
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -135,7 +135,7 @@ def test_read_map_file_fuzz(tmp_path: Path, text: str):
         ),
         (
             [{"tag": "tag1", "value": "x", "foo": "tag2", "bar": "y"}],
-            {("tag1", "x", "tag2", "y")},
+            {("tag1", "x")},
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import logging
+import os
 from ipaddress import IPv4Address
 from ipaddress import IPv6Address
 from pathlib import Path
 from typing import Dict
+from typing import Iterable
 from typing import List
 from typing import Set
 from typing import Tuple
 from typing import Union
+from unittest.mock import MagicMock
 
 import pytest
 from hypothesis import HealthCheck
@@ -18,6 +21,7 @@ from hypothesis import strategies as st
 from pytest import LogCaptureFixture
 
 from zabbix_auto_config import utils
+from zabbix_auto_config.models import Settings
 
 
 @pytest.mark.parametrize(
@@ -240,3 +244,65 @@ def test_mapping_values_with_prefix_no_prefix_separator(
     )
     assert res == {"user1@example.com": ["Foouser1-primary", "Foouser1-secondary"]}
     assert caplog.text.count("WARNING") == 2
+
+
+@pytest.fixture()
+def failsafe_ok_file(tmp_path: Path) -> Iterable[Path]:
+    failsafe_file = tmp_path / "failsafe"
+    try:
+        yield failsafe_file
+    finally:
+        if failsafe_file.exists():
+            os.chmod(failsafe_ok_file, 0o644)  # Ensure we can delete file
+            failsafe_file.unlink()
+
+
+def test_check_failsafe_ok_file_not_configured(config: Settings) -> None:
+    """Test that an unconfigured failsafe OK file always returns False"""
+    config.zac.failsafe_ok_file = None
+    assert utils.check_failsafe_ok(config.zac) is False
+
+
+@pytest.mark.parametrize("content", ["", "1"])
+def test_check_failsafe_ok_file_exists(
+    failsafe_ok_file: Path, config: Settings, content: str
+) -> None:
+    """Test that a failsafe ok file that exists is OK with and without content"""
+    config.zac.failsafe_ok_file = failsafe_ok_file
+    failsafe_ok_file.write_text(content)
+    assert utils.check_failsafe_ok(config.zac) is True
+    # Ensure that approving the file also deletes it
+    assert failsafe_ok_file.exists() is False
+
+
+def test_check_failsafe_ok_file_not_exists(
+    failsafe_ok_file: Path, config: Settings
+) -> None:
+    """Test that a missing failsafe OK file returns False"""
+    config.zac.failsafe_file = failsafe_ok_file
+    assert failsafe_ok_file.exists() is False
+    assert utils.check_failsafe_ok(config.zac) is False
+    assert failsafe_ok_file.exists() is False  # Should still not exist
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_check_failsafe_ok_file_unable_to_delete(
+    config: Settings, strict: bool
+) -> None:
+    """Test a failsafe OK file we are unable to delete."""
+    # NOTE: it's quite hard to mock a Path file with a real path
+    # so we instead mock the Path object with a MagicMock.
+    # An alternative would be to add a function we can pass Path objects
+    # to for deletion, then mock that function.
+    mock_file = MagicMock(spec=Path)
+    mock_file.exists.return_value = True
+    mock_file.unlink.side_effect = OSError("Unable to delete file")
+
+    assert mock_file.exists() is True
+    config.zac.failsafe_ok_file = mock_file
+    config.zac.failsafe_ok_file_strict = strict
+    # Fails in strict mode - must be able to delete the file
+    if strict:
+        assert utils.check_failsafe_ok(config.zac) is False
+    else:
+        assert utils.check_failsafe_ok(config.zac) is True

--- a/zabbix_auto_config/__init__.py
+++ b/zabbix_auto_config/__init__.py
@@ -20,16 +20,18 @@ from . import models
 from . import processing
 from .__about__ import __version__
 from ._types import HealthDict
-from ._types import SourceCollectorDict
+from ._types import HostModifier
+from ._types import HostModifierModule
+from ._types import SourceCollector
 from ._types import SourceCollectorModule
 from .state import get_manager
 
 
-def get_source_collectors(config: models.Settings) -> List[SourceCollectorDict]:
+def get_source_collectors(config: models.Settings) -> List[SourceCollector]:
     source_collector_dir = config.zac.source_collector_dir
     sys.path.append(source_collector_dir)
 
-    source_collectors = []  # type: List[SourceCollectorDict]
+    source_collectors = []  # type: List[SourceCollector]
     for (
         source_collector_name,
         source_collector_config,
@@ -43,23 +45,54 @@ def get_source_collectors(config: models.Settings) -> List[SourceCollectorDict]:
                 source_collector_dir,
             )
             continue
-
         if not isinstance(module, SourceCollectorModule):
             logging.error(
                 "Source collector named '%s' is not a valid source collector module",
                 source_collector_config.module_name,
             )
             continue
-
-        source_collector = {
-            "name": source_collector_name,
-            "module": module,
-            "config": source_collector_config,
-        }  # type: SourceCollectorDict
-
-        source_collectors.append(source_collector)
-
+        source_collectors.append(
+            SourceCollector(
+                name=source_collector_name,
+                module=module,
+                config=source_collector_config,
+            )
+        )
     return source_collectors
+
+
+def get_host_modifiers(modifier_dir: str) -> List[HostModifier]:
+    sys.path.append(modifier_dir)
+    try:
+        module_names = [
+            filename[:-3]
+            for filename in os.listdir(modifier_dir)
+            if filename.endswith(".py") and filename != "__init__.py"
+        ]
+    except FileNotFoundError:
+        logging.error("Host modififier directory %s does not exist.", modifier_dir)
+        sys.exit(1)
+    host_modifiers = []  # type: List[HostModifier]
+    for module_name in module_names:
+        module = importlib.import_module(module_name)
+        if not isinstance(module, HostModifierModule):
+            logging.warning(
+                "Module '%s' is not a valid host modifier module. Skipping.",
+                module_name,
+            )
+            continue
+        host_modifiers.append(
+            HostModifier(
+                name=module_name,
+                module=module,
+            )
+        )
+    logging.info(
+        "Loaded %d host modifiers: %s",
+        len(host_modifiers),
+        ", ".join([repr(modifier.name) for modifier in host_modifiers]),
+    )
+    return host_modifiers
 
 
 def get_config() -> models.Settings:
@@ -84,7 +117,7 @@ def write_health(
         "date_unixtime": int(now.timestamp()),
         "pid": os.getpid(),
         "cwd": os.getcwd(),
-        "all_ok": True,
+        "all_ok": all(p.state.ok for p in processes),
         "processes": [],
         "queues": [],
         "failsafe": failsafe,
@@ -99,8 +132,6 @@ def write_health(
                 **process.state.asdict(),
             }
         )
-
-    health["all_ok"] = all(p.state.ok for p in processes)
 
     for queue in queues:
         health["queues"].append(
@@ -142,23 +173,27 @@ def main() -> None:
     stop_event = multiprocessing.Event()
     state_manager = get_manager()
 
-    source_hosts_queues = []  # type: List[multiprocessing.Queue[models.Host]]
+    # Import host modifier and source collector modules
+    host_modifiers = get_host_modifiers(config.zac.host_modifier_dir)
     source_collectors = get_source_collectors(config)
 
+    # Initialize source collector processes from imported modules
+    source_hosts_queues = []  # type: List[multiprocessing.Queue[models.Host]]
     src_processes = []  # type: List[processing.BaseProcess]
     for source_collector in source_collectors:
         # Each source collector has its own queue
         source_hosts_queue = multiprocessing.Queue(maxsize=1)  # type: multiprocessing.Queue[models.Host]
         source_hosts_queues.append(source_hosts_queue)
         process: processing.BaseProcess = processing.SourceCollectorProcess(
-            source_collector["name"],
+            source_collector.name,
             state_manager.State(),
-            source_collector["module"],
-            source_collector["config"],
+            source_collector.module,
+            source_collector.config,
             source_hosts_queue,
         )
         src_processes.append(process)
 
+    # Initialize the other processes
     processes: List[processing.BaseProcess] = [
         processing.SourceHandlerProcess(
             "source-handler",
@@ -170,7 +205,7 @@ def main() -> None:
             "source-merger",
             state_manager.State(),
             config.zac.db_uri,
-            config.zac.host_modifier_dir,
+            host_modifiers,
         ),
         processing.ZabbixHostUpdater(
             "zabbix-host-updater",
@@ -195,13 +230,14 @@ def main() -> None:
     # Combine the source collector processes with the other processes
     processes.extend(src_processes)
 
-    # All processes must be st
+    # Abort if we can't start _all_ processes
     for pr in processes:
         try:
             pr.start()
         except Exception as e:
             logging.error("Unable to start process %s: %s", pr.name, e)
-            stop_event.set()  # Signal for us to stop the other proceses immediately
+            stop_event.set()  # Stop other proceses immediately
+            break
 
     with processing.SignalHandler(stop_event):
         status_interval = 60

--- a/zabbix_auto_config/__init__.py
+++ b/zabbix_auto_config/__init__.py
@@ -241,21 +241,22 @@ def main() -> None:
             logging.info("Terminating: %s(%d)", process.name, process.pid)
             pr.terminate()
 
-        alive_processes = [process for process in processes if process.is_alive()]
-        while alive_processes:
-            process = alive_processes[0]
-            logging.info("Waiting for: %s(%d)", process.name, process.pid)
-            log_process_status(processes)  # TODO: Too verbose?
-            process.join(10)
-            if process.exitcode is None:
-                logging.warning(
-                    "Process hanging. Signaling new terminate: %s(%d)",
-                    process.name,
-                    process.pid,
-                )
-                process.terminate()
+        def get_alive():
+            return [process for process in processes if process.is_alive()]
+
+        while alive := get_alive():
+            log_process_status(processes)
+            for process in alive:
+                logging.info("Waiting for: %s(%d)", process.name, process.pid)
+                process.join(10)
+                if process.exitcode is None:
+                    logging.warning(
+                        "Process hanging. Signaling new terminate: %s(%d)",
+                        process.name,
+                        process.pid,
+                    )
+                    process.terminate()
             time.sleep(1)
-            alive_processes = [process for process in processes if process.is_alive()]
 
     logging.info("Main exit")
 

--- a/zabbix_auto_config/__init__.py
+++ b/zabbix_auto_config/__init__.py
@@ -13,7 +13,7 @@ import time
 from pathlib import Path
 from typing import List
 
-import multiprocessing_logging
+import multiprocessing_logging  # type: ignore[import]
 import tomli
 
 from . import models

--- a/zabbix_auto_config/__init__.py
+++ b/zabbix_auto_config/__init__.py
@@ -274,7 +274,7 @@ def main() -> None:
         )
 
         for pr in processes:
-            logging.info("Terminating: %s(%d)", process.name, process.pid)
+            logging.info("Terminating: %s(%d)", pr.name, pr.pid)
             pr.terminate()
 
         def get_alive():

--- a/zabbix_auto_config/_types.py
+++ b/zabbix_auto_config/_types.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 from typing import List
+from typing import NamedTuple
 from typing import Protocol
 from typing import Sequence
 from typing import Set
@@ -47,16 +48,14 @@ class HostModifierModule(Protocol):
         ...
 
 
-class HostModifierDict(TypedDict):
-    """The dict created by
-    `zabbix_auto_config.processing.SourceMergerProcess.get_host_modifiers`
-    for each imported host modifier module."""
+class HostModifier(NamedTuple):
+    """An imported host modifier."""
 
     name: str
     module: HostModifierModule
 
 
-class SourceCollectorDict(TypedDict):
+class SourceCollector(NamedTuple):
     """The dict created by `zabbix_auto_config.get_source_collectors` for each
     imported source collector module."""
 

--- a/zabbix_auto_config/_types.py
+++ b/zabbix_auto_config/_types.py
@@ -49,3 +49,22 @@ class SourceCollectorDict(TypedDict):
     name: str
     module: SourceCollectorModule
     config: SourceCollectorSettings
+
+
+class QueueDict(TypedDict):
+    """Queue information for the health check dict."""
+
+    size: int
+
+
+class HealthDict(TypedDict):
+    """Application health dict used by `zabbix_auto_config.__init__.write_health`"""
+
+    date: str
+    date_unixtime: int
+    pid: int
+    cwd: str
+    all_ok: bool
+    processes: List[dict]
+    queues: List[QueueDict]
+    failsafe: int

--- a/zabbix_auto_config/_types.py
+++ b/zabbix_auto_config/_types.py
@@ -8,11 +8,25 @@ from __future__ import annotations
 from typing import Any
 from typing import List
 from typing import Protocol
+from typing import Sequence
+from typing import Set
+from typing import Tuple
 from typing import TypedDict
 from typing import runtime_checkable
 
 from .models import Host
 from .models import SourceCollectorSettings
+
+
+class ZabbixTag(TypedDict):
+    tag: str
+    value: str
+
+
+ZabbixTags = Sequence[ZabbixTag]
+
+ZacTag = Tuple[str, str]
+ZacTags = Set[ZacTag]
 
 
 @runtime_checkable

--- a/zabbix_auto_config/compat.py
+++ b/zabbix_auto_config/compat.py
@@ -1,0 +1,74 @@
+"""Compatibility functions to support different Zabbix API versions."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from packaging.version import Version
+
+# Compatibility methods for Zabbix API objects properties and method parameters.
+# Returns the appropriate property name for the given Zabbix version.
+#
+# FORMAT: <object>_<property>
+# EXAMPLE: user_name() (User object, name property)
+#
+# NOTE: All functions follow the same pattern:
+# Early return if the version is older than the version where the property
+# was deprecated, otherwise return the new property name as the default.
+
+
+def host_proxyid(version: Version) -> Literal["proxy_hostid", "proxyid"]:
+    # https://support.zabbix.com/browse/ZBXNEXT-8500
+    # https://www.zabbix.com/documentation/7.0/en/manual/api/changes#host
+    if version.release < (7, 0, 0):
+        return "proxy_hostid"
+    return "proxyid"
+
+
+def host_hostgroups(version: Version) -> Literal["groups", "hostgroups"]:
+    # https://support.zabbix.com/browse/ZBXNEXT-2592
+    # https://www.zabbix.com/documentation/6.2/en/manual/api/changes_6.0_-_6.2#host
+    if version.release < (6, 2, 0):
+        return "groups"
+    return "hostgroups"
+
+
+def proxy_name(version: Version) -> Literal["host", "name"]:
+    # https://support.zabbix.com/browse/ZBXNEXT-8500
+    # https://www.zabbix.com/documentation/7.0/en/manual/api/changes#proxy
+    if version.release < (7, 0, 0):
+        return "host"
+    return "name"
+
+
+def proxy_operating_mode(version: Version) -> Literal["status", "operating_mode"]:
+    # https://support.zabbix.com/browse/ZBXNEXT-8500
+    # https://www.zabbix.com/documentation/7.0/en/manual/api/changes#proxy
+    if version.release < (7, 0, 0):
+        return "status"
+    return "operating_mode"
+
+
+### API params
+# API parameter functions are in the following format:
+# param_<object>_<method>_<param>
+# So to get the "groups" parameter for the "host.get" method, you would call:
+# param_host_get_groups()
+
+
+def param_host_get_groups(
+    version: Version,
+) -> Literal["selectHostGroups", "selectGroups"]:
+    # https://support.zabbix.com/browse/ZBXNEXT-2592
+    # hhttps://www.zabbix.com/documentation/6.2/en/manual/api/changes_6.0_-_6.2#host
+    if version.release < (6, 2, 0):
+        return "selectGroups"
+    return "selectHostGroups"
+
+
+### Other compatibility functions
+
+
+def templategroups_supported(version: Version) -> bool:
+    """Return True if templategroups are supported in the given Zabbix version."""
+    return version.release >= (6, 2, 0)

--- a/zabbix_auto_config/failsafe.py
+++ b/zabbix_auto_config/failsafe.py
@@ -12,14 +12,14 @@ from zabbix_auto_config.models import ZacSettings
 def check_failsafe(config: Settings, to_add: List[str], to_remove: List[str]) -> None:
     """Check if number of hosts to add/remove exceeds the failsafe and handle appropriately."""
     failsafe = config.zabbix.failsafe
-    if len(to_remove) <= failsafe and len(to_add) <= config.failsafe:
+    if len(to_remove) <= failsafe and len(to_add) <= failsafe:
         return
 
     # Failsafe exceeded - check for failsafe OK file
     if check_failsafe_ok_file(config.zac):
         return
 
-    # Failsafe OK file does not exist or cannot be deleted.
+    # Failsafe OK file validation failed
     # We must write the hosts to add/remove and raise an exception
     write_failsafe_hosts(config.zac, to_add, to_remove)
     logging.warning(

--- a/zabbix_auto_config/failsafe.py
+++ b/zabbix_auto_config/failsafe.py
@@ -4,13 +4,42 @@ import logging
 from typing import List
 
 from zabbix_auto_config import models
+from zabbix_auto_config.exceptions import ZACException
+from zabbix_auto_config.models import Settings
 from zabbix_auto_config.models import ZacSettings
 
 
-def check_failsafe_ok(config: ZacSettings) -> bool:
-    """Checks the failsafe OK file and returns True if application should proceed."""
+def check_failsafe(config: Settings, to_add: List[str], to_remove: List[str]) -> None:
+    """Check if number of hosts to add/remove exceeds the failsafe and handle appropriately."""
+    failsafe = config.zabbix.failsafe
+    if len(to_remove) <= failsafe and len(to_add) <= config.failsafe:
+        return
+
+    # Failsafe exceeded - check for failsafe OK file
+    if check_failsafe_ok_file(config.zac):
+        return
+
+    # Failsafe OK file does not exist or cannot be deleted.
+    # We must write the hosts to add/remove and raise an exception
+    write_failsafe_hosts(config.zac, to_add, to_remove)
+    logging.warning(
+        "Too many hosts to change (failsafe=%d). Remove: %d, Add: %d. Aborting",
+        failsafe,
+        len(to_remove),
+        len(to_add),
+    )
+    raise ZACException("Failsafe triggered")
+
+
+def check_failsafe_ok_file(config: ZacSettings) -> bool:
+    """Check the failsafe OK file and returns True if application should proceed.
+
+    Attempts to delete the failsafe OK file if it exists.
+    Depending on the configuration, succeeding in deleting the file may
+    be required to proceed with changes."""
     # Check for presence of file
     if not config.failsafe_ok_file:
+        logging.info("No failsafe OK file configured.")
         return False
     if not config.failsafe_ok_file.exists():
         logging.info(
@@ -24,7 +53,8 @@ def check_failsafe_ok(config: ZacSettings) -> bool:
     except OSError as e:
         logging.error("Unable to delete failsafe OK file: %s", e)
         if config.failsafe_ok_file_strict:
-            return False
+            return False  # failed to delete in strict mode
+        # NOTE: should this be an INFO or DEBUG log instead?
         logging.warning("Continuing with changes despite failed deletion.")
     logging.info("Failsafe OK file exists. Proceeding with changes.")
     return True
@@ -33,17 +63,19 @@ def check_failsafe_ok(config: ZacSettings) -> bool:
 def write_failsafe_hosts(
     config: ZacSettings, to_add: List[str], to_remove: List[str]
 ) -> None:
-    """Writes a list of hosts to add and remove to a file when the failsafe is reached.
+    """Write a list of hosts to add and remove to a file when the failsafe is reached.
 
     Uses the failsafe file defined in the config.
     Does nothing if no failsafe file is defined.
     """
     if not config.failsafe_file:
-        logging.warning("Unable to write failsafe hosts. No failsafe file configured.")
+        logging.warning(
+            "No failsafe file configured, cannot write hosts to add/remove."
+        )
         return
     h = models.HostActions(add=to_add, remove=to_remove)
     h.write_json(config.failsafe_file)
     logging.info(
-        "Wrote list of hosts to add and remove to %s",
+        "Wrote list of hosts to add and remove: %s",
         config.failsafe_file,
     )

--- a/zabbix_auto_config/failsafe.py
+++ b/zabbix_auto_config/failsafe.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from zabbix_auto_config import models
+from zabbix_auto_config.models import ZacSettings
+
+
+def check_failsafe_ok(config: ZacSettings) -> bool:
+    """Checks the failsafe OK file and returns True if application should proceed."""
+    # Check for presence of file
+    if not config.failsafe_ok_file:
+        return False
+    if not config.failsafe_ok_file.exists():
+        logging.info(
+            "Failsafe OK file %s does not exist. Create it to approve changes.",
+            config.failsafe_ok_file,
+        )
+        return False
+    # File exists, attempt to delete it
+    try:
+        config.failsafe_ok_file.unlink()
+    except OSError as e:
+        logging.error("Unable to delete failsafe OK file: %s", e)
+        if config.failsafe_ok_file_strict:
+            return False
+        logging.warning("Continuing with changes despite failed deletion.")
+    logging.info("Failsafe OK file exists. Proceeding with changes.")
+    return True
+
+
+def write_failsafe_hosts(
+    config: ZacSettings, to_add: List[str], to_remove: List[str]
+) -> None:
+    """Writes a list of hosts to add and remove to a file when the failsafe is reached.
+
+    Uses the failsafe file defined in the config.
+    Does nothing if no failsafe file is defined.
+    """
+    if not config.failsafe_file:
+        logging.warning("Unable to write failsafe hosts. No failsafe file configured.")
+        return
+    h = models.HostActions(add=to_add, remove=to_remove)
+    h.write_json(config.failsafe_file)
+    logging.info(
+        "Wrote list of hosts to add and remove to %s",
+        config.failsafe_file,
+    )

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -209,18 +209,20 @@ class Interface(BaseModel):
 
 
 class Host(BaseModel):
+    # Required fields
     enabled: bool
     hostname: str
-
+    # Optional fields
     importance: Optional[Annotated[int, Field(ge=0)]] = None
     interfaces: List[Interface] = []
     inventory: Dict[str, str] = {}
-    macros: Optional[None] = None  # TODO: What should macros look like?
+    macros: Optional[Any] = None
     properties: Set[str] = set()
-    proxy_pattern: Optional[str] = None  # NOTE: replace with Optional[typing.Pattern]?
+    proxy_pattern: Optional[str] = None
     siteadmins: Set[str] = set()
     sources: Set[str] = set()
     tags: Set[Tuple[str, str]] = set()
+
     model_config = ConfigDict(validate_assignment=True, revalidate_instances="always")
 
     @model_validator(mode="before")

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -906,7 +906,7 @@ class ZabbixHostUpdater(ZabbixUpdater):
         If a failsafe OK file exists, the method will attempt to remove it
         and proceed with the changes. Otherwise, it will write the list of
         hosts to add and remove to a failsafe file and raise a ZACException."""
-        if self._check_failsafe_ok_file():
+        if utils.check_failsafe_ok(self.settings.zac):
             return
         # Failsafe OK file does not exist or cannot be deleted.
         # We must write the hosts to add/remove and raise an exception
@@ -931,28 +931,6 @@ class ZabbixHostUpdater(ZabbixUpdater):
             "Wrote list of hosts to add and remove to %s",
             self.settings.zac.failsafe_file,
         )
-
-    def _check_failsafe_ok_file(self) -> bool:
-        """Checks the failsafe OK file and returns True if application should proceed."""
-        # Check for presence of file
-        if not self.settings.zac.failsafe_ok_file:
-            return False
-        if not self.settings.zac.failsafe_ok_file.exists():
-            logging.info(
-                "Failsafe OK file %s does not exist. Create it to approve changes.",
-                self.settings.zac.failsafe_ok_file,
-            )
-            return False
-        # File exists, attempt to delete it
-        try:
-            self.settings.zac.failsafe_ok_file.unlink()
-        except OSError as e:
-            logging.error("Unable to delete failsafe OK file: %s", e)
-            if self.settings.zac.failsafe_ok_file_strict:
-                return False
-            logging.warning("Continuing with changes despite failed deletion.")
-        logging.info("Failsafe OK file exists. Proceeding with changes.")
-        return True
 
     def do_update(self):
         with self.db_connection, self.db_connection.cursor() as db_cursor:

--- a/zabbix_auto_config/state.py
+++ b/zabbix_auto_config/state.py
@@ -4,7 +4,7 @@ import time
 import types
 from dataclasses import asdict
 from multiprocessing.managers import BaseManager
-from multiprocessing.managers import NamespaceProxy
+from multiprocessing.managers import NamespaceProxy  # type: ignore[attr-defined]
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -72,10 +72,18 @@ class StateProxy(NamespaceProxy):
         return result
 
 
-Manager.register("State", State, proxytype=StateProxy)
+class StateManager(BaseManager):
+    """Custom subclass of BaseManager with type annotations for custom types."""
+
+    # We need to do this to make mypy happy with calling .State() on the manager class
+    # This stub will be overwritten by the actual method created by register()
+    def State(self) -> State: ...
 
 
-def get_manager() -> Manager:
-    m = Manager()
+StateManager.register("State", State, proxytype=StateProxy)
+
+
+def get_manager() -> StateManager:
+    m = StateManager()
     m.start()
     return m

--- a/zabbix_auto_config/state.py
+++ b/zabbix_auto_config/state.py
@@ -77,7 +77,7 @@ class StateManager(BaseManager):
 
     # We need to do this to make mypy happy with calling .State() on the manager class
     # This stub will be overwritten by the actual method created by register()
-    def State(self) -> State: ...
+    def State(self) -> State: ...  # type: ignore[empty-body]
 
 
 StateManager.register("State", State, proxytype=StateProxy)

--- a/zabbix_auto_config/state.py
+++ b/zabbix_auto_config/state.py
@@ -14,27 +14,36 @@ from pydantic.dataclasses import dataclass
 
 @dataclass
 class State:
+    """Health state of a process."""
+
     ok: bool = True
-    """True if process has not encountered an error in its most recent run."""
+    """Status of the process. False if an error has occurred in the most recent run."""
+
+    # BELOW: Only applicable if ok is False
+
     error: Optional[str] = None
-    """The error message if `ok` is False."""
+    """Error message for most recent error."""
+
     error_type: Optional[str] = None
-    """The type of error if `ok` is False."""
-    error_count: int = 0
-    """The number of errors the process has encountered."""
+    """Error type name for most recent error"""
+
     error_time: Optional[float] = None
-    """The timestamp of the most recent error."""
+    """Timestamp of the most recent error."""
+
+    error_count: int = 0
+    """Number of errors the process has encountered since starting."""
 
     def asdict(self) -> Dict[str, Any]:
         """Return dict representation of the State object."""
+        # NOTE: just construct dict ourselves instead?
         return asdict(self)
 
     def set_ok(self) -> None:
-        """Set the current state to OK, clear error information.
+        """Set current state to OK, clear error information.
 
         NOTE
         ----
-        This does not reset the error count.
+        Does not reset the error count.
         """
         self.ok = True
         self.error = None
@@ -42,6 +51,7 @@ class State:
         self.error_time = None
 
     def set_error(self, exc: Exception) -> None:
+        """Set current state to error and record error information."""
         self.ok = False
         self.error = str(exc)
         self.error_type = type(exc).__name__

--- a/zabbix_auto_config/utils.py
+++ b/zabbix_auto_config/utils.py
@@ -8,13 +8,15 @@ import multiprocessing
 import queue
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Dict
-from typing import Iterable
 from typing import List
 from typing import MutableMapping
-from typing import Set
-from typing import Tuple
 from typing import Union
+
+if TYPE_CHECKING:
+    from ._types import ZabbixTags
+    from ._types import ZacTags
 
 
 def is_valid_regexp(pattern: str):
@@ -33,13 +35,12 @@ def is_valid_ip(ip: str):
         return False
 
 
-def zabbix_tags2zac_tags(zabbix_tags: Iterable[Dict[str, str]]) -> Set[Tuple[str, ...]]:
-    return {tuple(tag.values()) for tag in zabbix_tags}
+def zabbix_tags2zac_tags(zabbix_tags: ZabbixTags) -> ZacTags:
+    return {(tag["tag"], tag["value"]) for tag in zabbix_tags}
 
 
-def zac_tags2zabbix_tags(zac_tags: Iterable[Tuple[str, str]]) -> List[Dict[str, str]]:
-    zabbix_tags = [{"tag": tag[0], "value": tag[1]} for tag in zac_tags]
-    return zabbix_tags
+def zac_tags2zabbix_tags(zac_tags: ZacTags) -> ZabbixTags:
+    return [{"tag": tag[0], "value": tag[1]} for tag in zac_tags]
 
 
 def read_map_file(path: Union[str, Path]) -> Dict[str, List[str]]:

--- a/zabbix_auto_config/utils.py
+++ b/zabbix_auto_config/utils.py
@@ -8,7 +8,6 @@ import multiprocessing
 import queue
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING
 from typing import Dict
 from typing import Iterable
 from typing import List
@@ -16,9 +15,6 @@ from typing import MutableMapping
 from typing import Set
 from typing import Tuple
 from typing import Union
-
-if TYPE_CHECKING:
-    from zabbix_auto_config.models import ZacSettings
 
 
 def is_valid_regexp(pattern: str):
@@ -205,26 +201,3 @@ def make_parent_dirs(path: Union[str, Path]) -> Path:
     except OSError as e:
         raise ValueError(f"Failed to create parent directories for {path}: {e}") from e
     return path
-
-
-def check_failsafe_ok(config: ZacSettings) -> bool:
-    """Checks the failsafe OK file and returns True if application should proceed."""
-    # Check for presence of file
-    if not config.failsafe_ok_file:
-        return False
-    if not config.failsafe_ok_file.exists():
-        logging.info(
-            "Failsafe OK file %s does not exist. Create it to approve changes.",
-            config.failsafe_ok_file,
-        )
-        return False
-    # File exists, attempt to delete it
-    try:
-        config.failsafe_ok_file.unlink()
-    except OSError as e:
-        logging.error("Unable to delete failsafe OK file: %s", e)
-        if config.failsafe_ok_file_strict:
-            return False
-        logging.warning("Continuing with changes despite failed deletion.")
-    logging.info("Failsafe OK file exists. Proceeding with changes.")
-    return True


### PR DESCRIPTION
This PR adds Zabbix 7.0 compatibility. There are numerous API changes in 7.0, for which a new `compat.py` module has been added.  This module adds functions that take in the current Zabbix API version and return the correct API method parameter / object property name.

The current implementation is a bit messy, and we will have to consider if we want to refactor all the API calls. Constructing large parameter dicts inline leads to some readability issuses, which we should try to mitigate. It's already kind of overloaded with long names and such.