### PR TITLE
Change log statement levels, change default level to INFO

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -9,7 +9,7 @@ host_modifier_dir = "path/to/host_modifier_dir/"
 db_uri = "dbname='zac' user='zabbix' host='localhost' password='secret' port=5432 connect_timeout=2"
 
 # Log level for the application.
-log_level = "DEBUG"
+log_level = "INFO"
 
 # Health status for each ZAC process.
 health_file = "/tmp/zac_health.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,6 @@ extend-select = [
 force-single-line = true
 # Add annotations import to every file
 required-imports = ["from __future__ import annotations"]
+
+[tool.pyright]
+pythonVersion = "3.8"

--- a/zabbix_auto_config/__init__.py
+++ b/zabbix_auto_config/__init__.py
@@ -280,7 +280,7 @@ def main() -> None:
 
             time.sleep(1)
 
-        logging.debug(
+        logging.info(
             "Queues: %s",
             ", ".join([str(queue.qsize()) for queue in source_hosts_queues]),
         )

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -143,7 +143,7 @@ class ZacSettings(ConfigBaseModel):
     source_collector_dir: str
     host_modifier_dir: str
     db_uri: str
-    log_level: int = Field(logging.DEBUG, description="The log level to use.")
+    log_level: int = Field(logging.INFO, description="The log level to use.")
     health_file: Optional[Path] = None
     failsafe_file: Optional[Path] = None
     failsafe_ok_file: Optional[Path] = None

--- a/zabbix_auto_config/pyzabbix/client.py
+++ b/zabbix_auto_config/pyzabbix/client.py
@@ -257,6 +257,12 @@ class ZabbixAPI:
         try:
             response = self.session.post(self.url, json=request_json)
         except Exception as e:
+            logging.error(
+                "Failed to send request to %s (%s) with params %s",
+                self.url,
+                method,
+                params,
+            )
             raise ZabbixAPIRequestError(
                 f"Failed to send request to {self.url} ({method}) with params {params}",
                 params=params,


### PR DESCRIPTION
This PR changes the log level of some informative log messages from DEBUG to INFO, so that switching log level from DEBUG to INFO does not cause a loss of important information about the state of the application.

This turns DEBUG logging into something that makes more sense to opt into for full introspection of the application's internal decision making process when required, but not something that should be enabled by default. The new default is INFO.