### PR TITLE
Optimize memory usage

### DIFF
--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -1185,8 +1185,8 @@ class ZabbixHostUpdater(ZabbixUpdater):
             else:
                 zabbix_managed_hosts.append(host)
 
-        db_hostnames = set(db_hosts.keys())
-        zabbix_hostnames = set(zabbix_hosts.keys())
+        db_hostnames = set(db_hosts)
+        zabbix_hostnames = set(zabbix_hosts)
         zabbix_managed_hostnames = {host.host for host in zabbix_managed_hosts}
         zabbix_manual_hostnames = {host.host for host in zabbix_manual_hosts}
 
@@ -1486,7 +1486,7 @@ class ZabbixTemplateUpdater(ZabbixUpdater):
             zabbix_templates[zabbix_template.host] = zabbix_template
 
         managed_template_names = managed_template_names.intersection(
-            set(zabbix_templates.keys())
+            set(zabbix_templates)
         )  # If the template isn't in zabbix we can't manage it
 
         # Get hosts from DB
@@ -1536,7 +1536,7 @@ class ZabbixTemplateUpdater(ZabbixUpdater):
             host_templates_to_remove: Dict[str, Template] = {}
 
             # Update templates on host
-            for template_name in list(host_templates.keys()):
+            for template_name in list(host_templates):
                 if (
                     template_name in managed_template_names
                     and template_name not in synced_template_names
@@ -1551,7 +1551,7 @@ class ZabbixTemplateUpdater(ZabbixUpdater):
                     ]
                     del host_templates[template_name]
             for template_name in synced_template_names:
-                if template_name not in host_templates.keys():
+                if template_name not in host_templates:
                     logging.debug(
                         "Going to add template '%s' to host '%s'.",
                         template_name,
@@ -1798,7 +1798,7 @@ class ZabbixHostgroupUpdater(ZabbixUpdater):
                 host_hostgroups[zabbix_hostgroup.name] = zabbix_hostgroup
             old_host_hostgroups = host_hostgroups.copy()
 
-            for hostgroup_name in list(host_hostgroups.keys()):
+            for hostgroup_name in list(host_hostgroups):
                 # TODO: Here lies a bug due to managed_hostgroup_names not being properly updated above?
                 # NOTE (pederhan): Not sure what this refers to?
                 if (

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -789,7 +789,7 @@ class ZabbixGarbageCollector(ZabbixUpdater):
             return
         # Get all disabled hosts
         disabled_hosts = self.api.get_hosts(status=MonitoringStatus.OFF)
-        self.cleanup_maintenances(disabled_hosts)
+        self.cleanup_maintenances(list(disabled_hosts))
 
 
 class ZabbixHostUpdater(ZabbixUpdater):
@@ -917,7 +917,7 @@ class ZabbixHostUpdater(ZabbixUpdater):
             return
 
         try:
-            hosts = self.api.get_hosts(hostname, search=False)
+            hosts = list(self.api.get_hosts(hostname, search=False))
 
             if hosts:
                 host = hosts[0]

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -1528,7 +1528,7 @@ class ZabbixTemplateUpdater(ZabbixUpdater):
                 if template_names := self.property_template_map.get(prop):
                     synced_template_names.update(template_names)
             synced_template_names = synced_template_names.intersection(
-                set(zabbix_templates.keys())
+                set(zabbix_templates)  # list of dict keys
             )  # If the template isn't in zabbix we can't manage it
 
             host_templates: Dict[str, Template] = {}

--- a/zabbix_auto_config/pyzabbix/client.py
+++ b/zabbix_auto_config/pyzabbix/client.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
+from typing import Iterator
 from typing import List
 from typing import Literal
 from typing import MutableMapping
@@ -618,6 +619,7 @@ class ZabbixAPI:
             status=status,
             agent_status=agent_status,
         )
+        hosts = list(hosts)  # consume the iterator
         if not hosts:
             raise ZabbixNotFoundError(
                 f"Host {name_or_id!r} not found. Check your search pattern and filters."
@@ -645,8 +647,7 @@ class ZabbixAPI:
         search: Optional[
             bool
         ] = True,  # we generally always want to search when multiple hosts are requested
-        # **filter_kwargs,
-    ) -> List[Host]:
+    ) -> Iterator[Host]:
         """Fetch all hosts matching the given criteria(s).
 
         Hosts can be filtered by name or ID. Names and IDs cannot be mixed.
@@ -751,7 +752,8 @@ class ZabbixAPI:
 
         resp: List[Any] = self.host.get(**params) or []
         # TODO add result to cache
-        return [Host(**resp) for resp in resp]
+        for r in resp:
+            yield Host.model_validate(r)
 
     def create_host(
         self,

--- a/zabbix_auto_config/pyzabbix/client.py
+++ b/zabbix_auto_config/pyzabbix/client.py
@@ -681,7 +681,9 @@ class ZabbixAPI:
         Returns:
             List[Host]: _description_
         """
-        params: ParamsType = {"output": ["hostid", "host"]}
+        params: ParamsType = {
+            "output": ["hostid", "host", "proxyid", "status", "inventory_mode"]
+        }
         filter_params: ParamsType = {}
         search_params: ParamsType = {}
 

--- a/zabbix_auto_config/pyzabbix/client.py
+++ b/zabbix_auto_config/pyzabbix/client.py
@@ -681,7 +681,7 @@ class ZabbixAPI:
         Returns:
             List[Host]: _description_
         """
-        params: ParamsType = {"output": "extend"}
+        params: ParamsType = {"output": ["hostid", "host"]}
         filter_params: ParamsType = {}
         search_params: ParamsType = {}
 
@@ -734,9 +734,9 @@ class ZabbixAPI:
             # still returns the result under the "groups" property
             # even if we use the new 6.2 selectHostGroups param
             param = compat.param_host_get_groups(self.version)
-            params[param] = "extend"
+            params[param] = ["groupid", "name"]
         if select_templates:
-            params["selectParentTemplates"] = "extend"
+            params["selectParentTemplates"] = ["templateid", "host"]
         if select_inventory:
             params["selectInventory"] = "extend"
         if select_macros:
@@ -1456,7 +1456,7 @@ class ZabbixAPI:
         select_parent_templates: bool = False,
     ) -> List[Template]:
         """Fetch one or more templates given a name or ID."""
-        params: ParamsType = {"output": "extend"}
+        params: ParamsType = {"output": ["templateid", "host"]}
         search_params: ParamsType = {}
 
         # TODO: refactor this along with other methods that take names or ids (or wildcards)
@@ -1476,11 +1476,11 @@ class ZabbixAPI:
         if search_params:
             params["search"] = search_params
         if select_hosts:
-            params["selectHosts"] = "extend"
+            params["selectHosts"] = ["hostid", "host"]
         if select_templates:
-            params["selectTemplates"] = "extend"
+            params["selectTemplates"] = ["templateid", "host"]
         if select_parent_templates:
-            params["selectParentTemplates"] = "extend"
+            params["selectParentTemplates"] = ["templateid", "host"]
 
         try:
             templates = self.template.get(**params)

--- a/zabbix_auto_config/pyzabbix/types.py
+++ b/zabbix_auto_config/pyzabbix/types.py
@@ -224,7 +224,7 @@ class Template(ZabbixAPIBaseModel):
 class TemplateGroup(ZabbixAPIBaseModel):
     groupid: str
     name: str
-    uuid: str
+    uuid: str = ""
     templates: List[Template] = []
 
 


### PR DESCRIPTION
This PR aims to reduce the memory usage after #81, which introduced Pydantic models for all API objects.

The PR makes the following adjustments:

- No longer uses `"output": "extend"` for many API methods, reducing the amount of data we fetch.
- Made `ZabbixAPI.get_hosts()` into a generator of `Host` objects instead of using a list comprehension to return a list.
- Removed redundant calls to `.keys()` on large dicts
