### PR TITLE
Compute default error duration if omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ For instance, with an `error_tolerance` of 5 and an `update_interval` of 60, `er
 
 A useful guide is to set `error_duration` as `(error_tolerance + 1) * update_interval`, providing an additional buffer equivalent to one update interval.
 
+If `error_tolerance` is set, but `error_duration` is not, the application will set an `error_duration` that is slightly longer than the minimum required to ensure correct error detection.
+
 #### exit_on_error
 
 `exit_on_error` (default: true) determines if the application should terminate, or disable the failing collector when number of errors exceed the tolerance. If set to `true`, the application will exit. Otherwise, the collector will be disabled for `disable_duration` seconds. For backwards compatibility with previous versions of Zabbix-auto-config, this option defaults to `true`. In a future major version, the default will be changed to `false`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest>=7.4.3", "pytest-timeout>=2.2.0", "hypothesis>=6.62.1"]
+test = ["pytest>=7.4.3", "pytest-timeout>=2.2.0", "hypothesis>=6.62.1", "inline-snapshot>=0.14.0"]
 
 [project.urls]
 Source = "https://github.com/unioslo/zabbix-auto-config"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,9 @@ import logging
 
 import pytest
 import tomli
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
 from inline_snapshot import snapshot
 from pydantic import ValidationError
 
@@ -92,6 +95,22 @@ def test_sourcecollectorsettings_no_error_duration():
     )
 
     assert settings.error_duration == snapshot(354)
+
+
+@given(
+    update_interval=st.integers(min_value=0, max_value=100),
+    error_tolerance=st.integers(min_value=0, max_value=100),
+)
+@settings(max_examples=1000)
+def test_sourcecollectorsettings_no_error_duration_fuzz(
+    update_interval: int, error_tolerance: int
+):
+    """Test model with a variety of update intervals and error tolerances"""
+    models.SourceCollectorSettings(
+        module_name="foo",
+        update_interval=update_interval,
+        error_tolerance=error_tolerance,
+    )
 
 
 def test_sourcecollectorsettings_duration_too_short():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import logging
 
 import pytest
 import tomli
+from inline_snapshot import snapshot
 from pydantic import ValidationError
 
 import zabbix_auto_config.models as models
@@ -69,13 +70,10 @@ def test_sourcecollectorsettings_no_tolerance() -> None:
         error_duration=0,
     )
     assert settings.error_tolerance == 0
-    # In case the actual implementaiton changes in the future, we don't
-    # want to test the _exact_ value, but we know it will not be 0
-    assert settings.error_duration > 0
+    assert settings.error_duration == snapshot(9999)
 
 
 def test_sourcecollectorsettings_no_error_duration():
-    # TODO: check if we can just remove this test
     # In order to not have an error_duration, error_tolerance must be 0 too
     settings = models.SourceCollectorSettings(
         module_name="foo",
@@ -83,18 +81,17 @@ def test_sourcecollectorsettings_no_error_duration():
         error_duration=0,
         error_tolerance=0,
     )
-    # See docstring in test_sourcecollectorsettings_no_tolerance
-    assert settings.error_duration > 0
+    assert settings.error_duration == snapshot(9999)
 
-    # With tolerance raises an error
-    # NOTE: we test the error message in depth in test_sourcecollectorsettings_invalid_error_duration
-    with pytest.raises(ValidationError):
-        models.SourceCollectorSettings(
-            module_name="foo",
-            update_interval=60,
-            error_duration=0,
-            error_tolerance=5,
-        )
+    # With tolerance we get a default value
+    settings = models.SourceCollectorSettings(
+        module_name="foo",
+        update_interval=60,
+        error_duration=0,
+        error_tolerance=5,
+    )
+
+    assert settings.error_duration == snapshot(354)
 
 
 def test_sourcecollectorsettings_duration_too_short():
@@ -112,6 +109,9 @@ def test_sourcecollectorsettings_duration_too_short():
     error = errors[0]
     assert "greater than 300" in error["msg"]
     assert error["type"] == "value_error"
+    assert error["msg"] == snapshot(
+        "Value error, Invalid value for error_duration (180). It should be greater than 300: error_tolerance (5) * update_interval (60)"
+    )
 
 
 def test_sourcecollectorsettings_duration_negative():


### PR DESCRIPTION
This PR adds a computed default for a source collector's `error_duration` based on its `update_interval` and `error_tolerance`. 

Given a the following config, we can expect ZAC to compute a default value for `error_duration` that is between 300 and 359 seconds:

```toml
[source_collectors.faultysource]
module_name = "faultysource"
update_interval = 60
error_tolerance = 5
exit_on_err = false
```

This PR uses the following formula to compute the default value: `round(error_tolerance * update_interval + (update_interval*0.9))`. So for the config above, we will get a default `error_duration` of 354.

The extra duration (`update_interval*0.9`) allows for some accumulated latency during and between updates, while still ensuring 5 _successive_ errors are required to trigger deactivation.