### PR TITLE
Add update interval exponential backoff on source collector failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## Unreleased
+
+### Added
+
+- Default value for source collector config `source_collectors.<name>.error_duration` is now computed from `round(error_tolerance * update_interval + (update_interval*0.9))`
+
+### Changed
+
+- Source collectors are now disabled on error by default instead of terminating the process.
+  - The old behavior can be restored by setting `source_collectors.<name>.exit_on_error = true` on the relevant source collectors.
 
 ## [0.2.0](https://github.com/unioslo/zabbix-auto-config/releases/tag/zac-v0.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Default value for source collector config `source_collectors.<name>.error_duration` is now computed from `round(error_tolerance * update_interval + (update_interval*0.9))`
+- New failure handling strategies for source collectors, which can be set using `disable_duration` for each source collector.
+  - `disable_duration == 0` (default): Use exponential backoff to increase the update interval on error. The update interval is reset to the original value on success.
+  - `disable_duration > 0`: Disable the source collector for a set duration.
+  - `disable_duration < 0`: Do not disable the source collector on error.
+  - `exit_on_error` takes precedence over `disable_duration`. If `exit_on_error` is set to `true`, the source collector will exit on error regardless of the `disable_duration` setting.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- A Source Collector `disable_duration` of 0 will now skip disabling the the source collector on error instead of disabling it indefinitely.
+- The default value of `exit_on_error` for source collectors is now `false`.
+- The default value of `disable_duration` for source collectors is now `0`. This means that the source collector will use exponential backoff to increase the update interval on error.
 
 ## [0.2.0](https://github.com/unioslo/zabbix-auto-config/releases/tag/zac-v0.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Source collectors are now disabled on error by default instead of terminating the process.
-  - The old behavior can be restored by setting `source_collectors.<name>.exit_on_error = true` on the relevant source collectors.
+- A Source Collector `disable_duration` of 0 will now skip disabling the the source collector on error instead of disabling it indefinitely.
 
 ## [0.2.0](https://github.com/unioslo/zabbix-auto-config/releases/tag/zac-v0.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New failure handling strategies for source collectors, which can be set using `disable_duration` for each source collector.
   - `disable_duration == 0` (default): Use exponential backoff to increase the update interval on error. The update interval is reset to the original value on success.
   - `disable_duration > 0`: Disable the source collector for a set duration.
-  - `disable_duration < 0`: Do not disable the source collector on error.
+  - `disable_duration < 0`: Never disable, never increase the update interval.
   - `exit_on_error` takes precedence over `disable_duration`. If `exit_on_error` is set to `true`, the source collector will exit on error regardless of the `disable_duration` setting.
 
 ### Changed

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -98,29 +98,67 @@ module_name = "mysource"
 # How often to run the source collector in seconds
 update_interval = 60
 
-# How many errors to tolerate before disabling the source
-error_tolerance = 5 # Tolerate 5 errors within `error_duration` seconds
-
-# How long an error should be kept in the error tally before discarding it
-error_duration = 360 # should be greater than update_interval
-
-# Exit the application if the source fails
-# If true, the application will exit if the source fails
-# If false, the source will be disabled for `disable_duration` seconds
-exit_on_error = false # Disable source if it fails
-
-# How long to wait before reactivating a disabled source
-disable_duration = 3600 # Time in seconds to wait before reactivating a disabled source
-
 # Any other options are passed as keyword arguments to the source collector's
 # `collect()` function
 kwarg_passed_to_source = "value" # extra fields are passed to the source module as kwargs
 another_kwarg = "value2"         # We can pass an arbitrary number of kwargs to the source module
 
 
-[source_collectors.othersource]
-module_name = "mysource"
+# We can define multiple sources using the same module as long
+# as their config entries have different names
+[source_collectors.othersource] # different name
+module_name = "mysource" # same module as above
 update_interval = 60
-error_tolerance = 0      # no tolerance for errors (default)
-exit_on_error = true     # exit application if source fails (default)
-source = "other"         # extra kwarg used in mysource module
+
+# By default, the application applies an exponential backoff to sources
+# that fail to collect data due to network issues or other problems.
+# The backoff factor is multiplied by the update interval to determine
+# how long to wait before retrying the source.
+# The default backoff factor is 1.5. Backoff is disabled if the factor is 1.
+backoff_factor = 2 # Increase the backoff factor for this source
+
+# We can limit how long the backoff time can grow to prevent a source
+# from waiting too long between retries.
+max_backoff = 3600 # Maximum backoff time in seconds
+
+
+[source_collectors.error_tolerance_source]
+module_name = "mysource" # re-using same module
+update_interval = 60
+
+# Error tolerance settings
+#
+# We can define a custom error tolerance for each source collector.
+# By setting an error tolerance, exponential backoff is disabled for the source
+# and the source will keep retrying at the same interval until it succeeds
+# or hits the error tolerance.
+
+# By setting `error_tolerance` and `error_duration` we can control how many
+# errors within a certain timespan are tolerated before the source is disabled
+# for a certain duration.
+
+# How many errors to tolerate before disabling the source
+error_tolerance = 5 # Tolerate 5 errors within `error_duration` seconds
+
+# How long an error should be kept in the error tally before discarding it
+# In this case, we consider 5 errors or more within 10 minutes as a failure
+error_duration = 600 # should be greater than update_interval
+
+# Duration to disable source if error threshold is reached
+# If this is set to 0, error tolerance is disabled, and the source will
+# go back to using exponential backoff as its retry strategy.
+disable_duration = 3600 # time in seconds (1 hour)
+
+# Exit the application if the source fails
+# If true, the application will exit if the source fails
+# If false, the source will be disabled for `disable_duration` seconds
+exit_on_error = false # Disable source if it fails
+
+[source_collectors.no_error_handling_source]
+module_name = "mysource" # re-using same module
+update_interval = 60
+
+# If disable_duration is set to a negative value, the source uses neither
+# exponential backoff nor error tolerance. It will keep retrying at the
+# same pace no matter how many errors it encounters.
+disable_duration = -1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,6 +47,11 @@ def test_sourcecollectorsettings_defaults():
         module_name="foo",
         update_interval=60,
     )
+
+    # Default strategy should be to use exponential backoff
+    assert settings.failure_strategy == models.FailureStrategy.BACKOFF
+
+    # Snapshot of values
     assert settings.model_dump() == snapshot(
         {
             "module_name": "foo",
@@ -56,6 +61,7 @@ def test_sourcecollectorsettings_defaults():
             "exit_on_error": False,
             "disable_duration": 0,
             "backoff_factor": 1.5,
+            "max_backoff": 3600,
         }
     )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -210,3 +210,12 @@ def test_zabbix_settings_timeout(timeout: int, expect: Optional[int]) -> None:
         timeout=timeout,
     )
     assert settings.timeout == expect
+
+
+def test_failure_strategy_supports_error_tolerance() -> None:
+    """Test that only EXIT and DISABLE support error tolerance."""
+    for strategy in models.FailureStrategy:
+        if strategy in (models.FailureStrategy.EXIT, models.FailureStrategy.DISABLE):
+            assert strategy.supports_error_tolerance()
+        else:
+            assert not strategy.supports_error_tolerance()

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -214,12 +214,12 @@ class SourceCollectorSettings(ConfigBaseModel, extra="allow"):
     module_name: str
     update_interval: int
     error_tolerance: int = Field(
-        0,
+        default=0,
         description="Number of errors to allow within the last `error_duration` seconds before marking the collector as failing.",
         ge=0,
     )
     error_duration: int = Field(
-        0,
+        default=0,
         description=(
             "The duration in seconds that errors are stored."
             "If `error_tolerance` errors occur in this period, the collector is marked as failing."
@@ -228,15 +228,15 @@ class SourceCollectorSettings(ConfigBaseModel, extra="allow"):
         ge=0,
     )
     exit_on_error: bool = Field(
-        False,
+        default=False,
         description="Exit ZAC if the collector failure tolerance is exceeded. Collector is disabled otherwise.",
     )
     disable_duration: int = Field(
-        0,
+        default=0,
         description="Duration to disable the collector for if the error tolerance is exceeded.",
     )
     backoff_factor: float = Field(
-        1.5,
+        default=1.5,
         description="Factor to multiply the update interval by when the collector is disabled.",
         ge=1.0,
     )

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -218,7 +218,7 @@ class SourceCollectorSettings(ConfigBaseModel, extra="allow"):
         ge=0,
     )
     exit_on_error: bool = Field(
-        True,
+        False,
         description="Exit ZAC if the collector failure tolerance is exceeded. Collector is disabled otherwise.",
     )
     disable_duration: int = Field(

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -218,7 +218,7 @@ class SourceCollectorSettings(ConfigBaseModel, extra="allow"):
         ge=0,
     )
     exit_on_error: bool = Field(
-        False,
+        True,
         description="Exit ZAC if the collector failure tolerance is exceeded. Collector is disabled otherwise.",
     )
     disable_duration: int = Field(

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -234,13 +234,15 @@ class SourceCollectorProcess(BaseProcess):
             self.disabled_until = datetime.datetime.now() + datetime.timedelta(
                 seconds=disable_duration
             )
+            # Reset the error counter so that previous errors don't count towards
+            # the error counter in the next run in case the disable duration is short
+            self.error_counter.reset()
         else:
-            logging.info("Disabling source '%s' indefinitely", self.name)
-            self.disabled_until = datetime.datetime.max
+            logging.info(
+                "Source '%s' has a disable duration of 0. Keeping it enabled...",
+                self.name,
+            )
 
-        # Reset the error counter so that previous errors don't count towards
-        # the error counter in the next run in case the disable duration is short
-        self.error_counter.reset()
         # TODO: raise specific exception here instead of ZACException
 
     def collect(self) -> None:

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -209,7 +209,7 @@ class SourceCollectorProcess(BaseProcess):
         else:
             self.handle_success()
 
-    def add_backoff(self) -> None:
+    def increase_update_interval(self) -> None:
         """Increase the update interval by the backoff factor."""
         self.update_interval *= self.config.backoff_factor
         logging.info(
@@ -218,8 +218,8 @@ class SourceCollectorProcess(BaseProcess):
             self.update_interval,
         )
 
-    def reset_backoff(self) -> None:
-        """Reset the update interval to the original value."""
+    def reset_update_interval(self) -> None:
+        """Reset the update interval to its original value."""
         if self.update_interval == self.config.update_interval:
             return  # Nothing to do
         self.update_interval = self.config.update_interval
@@ -231,7 +231,7 @@ class SourceCollectorProcess(BaseProcess):
 
     def handle_success(self) -> None:
         """Handle a successful collection."""
-        self.reset_backoff()
+        self.reset_update_interval()
 
     def handle_error(self, e: Exception) -> None:
         """Handle exceptions raised during collection."""
@@ -243,7 +243,7 @@ class SourceCollectorProcess(BaseProcess):
             if strat == models.FailureStrategy.DISABLE:
                 self.disable()
             elif strat == models.FailureStrategy.BACKOFF:
-                self.add_backoff()
+                self.increase_update_interval()
             elif strat == models.FailureStrategy.EXIT:
                 self.stop_event.set()
             else:


### PR DESCRIPTION
This PR implements more sensible failure strategy defaults for source collector errors. The following is changed:

1. The error tolerance stuff is now opt-in by default.
2. The default strategy for source collector errors is now to apply a delay using exponential backoff to the source's update interval on failure.
3. `exit_on_error` is now `False` by default, and must be opted in to. The default behavior is now to use the backoff strategy outlined above. This is technically a breaking change, as failing sources would terminate the application prior to this PR.

All in all, this PR brings in more sensible error handling defaults for source collectors and makes the application more likely to recover from intermittent errors.

