### PR TITLE
Refactor health file

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import datetime
 
-from inline_snapshot import snapshot
-
 from zabbix_auto_config.health import HealthFile
 from zabbix_auto_config.health import ProcessInfo
 from zabbix_auto_config.state import State
@@ -35,35 +33,5 @@ def test_healthfile_to_json() -> None:
         ],
     )
 
-    # NOTE: timedeltas are serialized as `PT#S` where # is the number of seconds
-    assert health_file.to_json() == snapshot(
-        """\
-{
-  "date": "2021-01-01T00:00:00",
-  "cwd": "/path/to/zac",
-  "pid": 1234,
-  "processes": [
-    {
-      "name": "test_process",
-      "pid": 1235,
-      "alive": true,
-      "state": {
-        "ok": false,
-        "error": "Test error",
-        "error_type": "CustomException",
-        "error_time": 1736951323.874142,
-        "error_count": 1,
-        "execution_count": 3,
-        "total_duration": "PT4S",
-        "max_duration": "PT2S",
-        "last_duration_warning": "2021-01-02T00:00:00"
-      }
-    }
-  ],
-  "queues": [],
-  "failsafe": 123,
-  "date_unixtime": 1609455600,
-  "all_ok": true
-}\
-"""
-    )
+    # Check that we can call to_json() without errors
+    assert health_file.to_json()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -9,9 +9,7 @@ from zabbix_auto_config.health import ProcessInfo
 from zabbix_auto_config.state import State
 
 
-def test_healthfile_to_json(health_file: HealthFile) -> None:
-    # NOTE: timedeltas are serialized as `PT#S` where # is the number of seconds
-
+def test_healthfile_to_json() -> None:
     health_file = HealthFile(
         date=datetime.datetime(2021, 1, 1, 0, 0, 0),
         cwd="/path/to/zac",
@@ -36,6 +34,8 @@ def test_healthfile_to_json(health_file: HealthFile) -> None:
             )
         ],
     )
+
+    # NOTE: timedeltas are serialized as `PT#S` where # is the number of seconds
     assert health_file.to_json() == snapshot(
         """\
 {

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import datetime
+
+from inline_snapshot import snapshot
+
+from zabbix_auto_config.health import HealthFile
+from zabbix_auto_config.health import ProcessInfo
+from zabbix_auto_config.state import State
+
+
+def test_healthfile_to_json(health_file: HealthFile) -> None:
+    # NOTE: timedeltas are serialized as `PT#S` where # is the number of seconds
+
+    health_file = HealthFile(
+        date=datetime.datetime(2021, 1, 1, 0, 0, 0),
+        cwd="/path/to/zac",
+        pid=1234,
+        failsafe=123,
+        processes=[
+            ProcessInfo(
+                name="test_process",
+                pid=1235,
+                alive=True,
+                state=State(
+                    ok=False,
+                    error="Test error",
+                    error_type="CustomException",
+                    error_count=1,
+                    error_time=1736951323.874142,
+                    execution_count=3,
+                    total_duration=datetime.timedelta(seconds=4),
+                    max_duration=datetime.timedelta(seconds=2),
+                    last_duration_warning=datetime.datetime(2021, 1, 2, 0, 0, 0),
+                ),
+            )
+        ],
+    )
+    assert health_file.to_json() == snapshot(
+        """\
+{
+  "date": "2021-01-01T00:00:00",
+  "cwd": "/path/to/zac",
+  "pid": 1234,
+  "processes": [
+    {
+      "name": "test_process",
+      "pid": 1235,
+      "alive": true,
+      "state": {
+        "ok": false,
+        "error": "Test error",
+        "error_type": "CustomException",
+        "error_time": 1736951323.874142,
+        "error_count": 1,
+        "execution_count": 3,
+        "total_duration": "PT4S",
+        "max_duration": "PT2S",
+        "last_duration_warning": "2021-01-02T00:00:00"
+      }
+    }
+  ],
+  "queues": [],
+  "failsafe": 123,
+  "date_unixtime": 1609455600,
+  "all_ok": true
+}\
+"""
+    )

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -2,12 +2,23 @@ from __future__ import annotations
 
 import datetime
 
+import pytest
+
 from zabbix_auto_config.health import HealthFile
 from zabbix_auto_config.health import ProcessInfo
 from zabbix_auto_config.state import State
+from zabbix_auto_config.state import get_manager
 
 
-def test_healthfile_to_json() -> None:
+@pytest.mark.parametrize("use_manager", [True, False])
+def test_healthfile_to_json(use_manager: bool) -> None:
+    # Test with and without proxied classes
+    if use_manager:
+        man = get_manager()
+        s = man.State()
+    else:
+        s = State()
+
     health_file = HealthFile(
         date=datetime.datetime(2021, 1, 1, 0, 0, 0),
         cwd="/path/to/zac",
@@ -18,17 +29,7 @@ def test_healthfile_to_json() -> None:
                 name="test_process",
                 pid=1235,
                 alive=True,
-                state=State(
-                    ok=False,
-                    error="Test error",
-                    error_type="CustomException",
-                    error_count=1,
-                    error_time=1736951323.874142,
-                    execution_count=3,
-                    total_duration=datetime.timedelta(seconds=4),
-                    max_duration=datetime.timedelta(seconds=2),
-                    last_duration_warning=datetime.datetime(2021, 1, 2, 0, 0, 0),
-                ),
+                state=s,
             )
         ],
     )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -153,8 +153,8 @@ def test_state_asdict_ok(use_manager: bool) -> None:
             "error_time": None,
             "error_count": 0,
             "execution_count": 0,
-            "total_duration": datetime.timedelta(0),
-            "max_duration": datetime.timedelta(0),
+            "total_duration": 0.0,
+            "max_duration": 0.0,
             "last_duration_warning": None,
         }
     )
@@ -188,8 +188,8 @@ def test_state_asdict_error(use_manager: bool) -> None:
             "error_type": "CustomException",
             "error_count": 1,
             "execution_count": 0,
-            "total_duration": datetime.timedelta(0),
-            "max_duration": datetime.timedelta(0),
+            "total_duration": 0.0,
+            "max_duration": 0.0,
             "last_duration_warning": None,
         }
     )

--- a/zabbix_auto_config/_types.py
+++ b/zabbix_auto_config/_types.py
@@ -62,22 +62,3 @@ class SourceCollector(NamedTuple):
     name: str
     module: SourceCollectorModule
     config: SourceCollectorSettings
-
-
-class QueueDict(TypedDict):
-    """Queue information for the health check dict."""
-
-    size: int
-
-
-class HealthDict(TypedDict):
-    """Application health dict used by `zabbix_auto_config.__init__.write_health`"""
-
-    date: str
-    date_unixtime: int
-    pid: int
-    cwd: str
-    all_ok: bool
-    processes: List[dict]
-    queues: List[QueueDict]
-    failsafe: int

--- a/zabbix_auto_config/health.py
+++ b/zabbix_auto_config/health.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import computed_field
+from pydantic import field_serializer
+
+from zabbix_auto_config import processing
+from zabbix_auto_config.state import State
+
+
+class HealthFile(BaseModel):
+    """Health file for the application."""
+
+    date: datetime = Field(default_factory=datetime.now)
+    cwd: str
+    pid: int
+    processes: list[ProcessInfo] = []
+    queues: list[QueueInfo] = []
+    failsafe: int
+
+    @computed_field
+    @property
+    def date_unixtime(self) -> int:
+        return int(self.date.timestamp())
+
+    @computed_field
+    @property
+    def all_ok(self) -> bool:
+        return all(p.alive for p in self.processes)
+
+    @field_serializer("date", when_used="json")
+    def serialize_date(self, value: datetime) -> str:
+        return value.isoformat(timespec="seconds")
+
+    def to_json(self) -> str:
+        return self.model_dump_json(indent=2)
+
+
+class ProcessInfo(BaseModel):
+    name: str
+    pid: Optional[int]
+    alive: bool
+    state: State
+
+
+class QueueInfo(BaseModel):
+    size: int
+
+
+def write_health(
+    health_file: Path,
+    processes: list[processing.BaseProcess],
+    queues: list[multiprocessing.Queue],
+    failsafe: int,
+) -> None:
+    health = HealthFile(
+        cwd=os.getcwd(),
+        pid=os.getpid(),
+        failsafe=failsafe,
+    )
+
+    for process in processes:
+        health.processes.append(
+            ProcessInfo(
+                name=process.name,
+                pid=process.pid,
+                alive=process.is_alive(),
+                state=process.state,
+            )
+        )
+
+    for queue in queues:
+        health.queues.append(
+            QueueInfo(
+                size=queue.qsize(),
+            )
+        )
+
+    try:
+        with open(health_file, "w") as f:
+            f.write(health.to_json())
+    except Exception as e:
+        logging.error("Unable to write health file %s: %s", health_file, e)

--- a/zabbix_auto_config/health.py
+++ b/zabbix_auto_config/health.py
@@ -5,6 +5,7 @@ import multiprocessing
 import os
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 from typing import List
 from typing import Optional
 
@@ -12,9 +13,11 @@ from pydantic import BaseModel
 from pydantic import Field
 from pydantic import computed_field
 from pydantic import field_serializer
+from pydantic import field_validator
 
 from zabbix_auto_config import processing
 from zabbix_auto_config.state import State
+from zabbix_auto_config.state import StateProxy
 
 
 class ProcessInfo(BaseModel):
@@ -22,6 +25,13 @@ class ProcessInfo(BaseModel):
     pid: Optional[int]
     alive: bool
     state: State
+
+    @field_validator("state", mode="before")
+    @classmethod
+    def validate_state(cls, value: State) -> Any:
+        if isinstance(value, StateProxy):
+            return value._getvalue()
+        return value
 
 
 class QueueInfo(BaseModel):

--- a/zabbix_auto_config/health.py
+++ b/zabbix_auto_config/health.py
@@ -16,6 +16,17 @@ from zabbix_auto_config import processing
 from zabbix_auto_config.state import State
 
 
+class ProcessInfo(BaseModel):
+    name: str
+    pid: Optional[int]
+    alive: bool
+    state: State
+
+
+class QueueInfo(BaseModel):
+    size: int
+
+
 class HealthFile(BaseModel):
     """Health file for the application."""
 
@@ -42,17 +53,6 @@ class HealthFile(BaseModel):
 
     def to_json(self) -> str:
         return self.model_dump_json(indent=2)
-
-
-class ProcessInfo(BaseModel):
-    name: str
-    pid: Optional[int]
-    alive: bool
-    state: State
-
-
-class QueueInfo(BaseModel):
-    size: int
 
 
 def write_health(

--- a/zabbix_auto_config/health.py
+++ b/zabbix_auto_config/health.py
@@ -5,6 +5,7 @@ import multiprocessing
 import os
 from datetime import datetime
 from pathlib import Path
+from typing import List
 from typing import Optional
 
 from pydantic import BaseModel
@@ -33,8 +34,8 @@ class HealthFile(BaseModel):
     date: datetime = Field(default_factory=datetime.now)
     cwd: str
     pid: int
-    processes: list[ProcessInfo] = []
-    queues: list[QueueInfo] = []
+    processes: List[ProcessInfo] = []
+    queues: List[QueueInfo] = []
     failsafe: int
 
     @computed_field


### PR DESCRIPTION
Fixes health file failing to serialize to JSON with the new `State` fields introduced in #93. 

This PR also rewrites the following as Pydantic models for easier and more consistent JSON serialization:

- Health file
- State