### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Note: Primarily tested with Zabbix 7.0 and 6.4, but should work with 6.0 and 5.2
 
 ## Requirements
 
-* Python >=3.8
+* Python >=3.9
 * pip >=21.3
 * Zabbix >=6.4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "zabbix-auto-config"
 dynamic = ["version"]
 description = "Zabbix auto config - ZAC"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license.file = "LICENSE"
 keywords = []
 authors = [{ name = "Paal Braathen", email = "paal.braathen@usit.uio.no" }]
@@ -19,7 +19,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -77,4 +76,4 @@ force-single-line = true
 required-imports = ["from __future__ import annotations"]
 
 [tool.pyright]
-pythonVersion = "3.8"
+pythonVersion = "3.9"


### PR DESCRIPTION
3.8 is EOL.