### PR TITLE
Refactor failure strategy handler selection

### DIFF
--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -285,6 +285,13 @@ class SourceCollectorProcess(BaseProcess):
                 or self.error_counter.tolerance_exceeded()
             ):
                 handler()
+            else:
+                logging.debug(
+                    "Source '%s' has not reached error tolerance of %d (current: %d) Keeping it enabled...",
+                    self.name,
+                    self.config.error_tolerance,
+                    self.error_counter.count(),
+                )
         else:
             logging.info(
                 "Source '%s' has no failure handling strategy. Keeping it enabled...",

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -272,23 +272,25 @@ class SourceCollectorProcess(BaseProcess):
         logging.error("Collect exception: %s", str(e))
         self.error_counter.add(exception=e)
 
+        strat_handlers = {
+            models.FailureStrategy.BACKOFF: self.increase_update_interval,
+            models.FailureStrategy.EXIT: self.stop,
+            models.FailureStrategy.DISABLE: self.disable,
+        }
         strat = self.config.failure_strategy
 
-        # Handle immediate strategies (no tolerance check needed)
-        if strat == models.FailureStrategy.BACKOFF:
-            self.increase_update_interval()
-        # Handle tolerance-based strategies
-        elif strat.supports_error_tolerance():
-            if self.error_counter.tolerance_exceeded():
-                if strat == models.FailureStrategy.EXIT:
-                    self.stop()
-                elif strat == models.FailureStrategy.DISABLE:
-                    self.disable()
+        if handler := strat_handlers.get(strat):
+            if (
+                not strat.supports_error_tolerance()
+                or self.error_counter.tolerance_exceeded()
+            ):
+                handler()
         else:
             logging.info(
                 "Source '%s' has no failure handling strategy. Keeping it enabled...",
                 self.name,
             )
+
         raise ZACException(f"Failed to collect from source {self.name!r}: {e}") from e
 
     def disable(self) -> None:

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -298,7 +298,7 @@ class SourceCollectorProcess(BaseProcess):
                 logging.debug(
                     "Source '%s' has not reached error tolerance of %d (current: %d) Keeping it enabled...",
                     self.name,
-                    self.config.error_tolerance,
+                    self.settings.error_tolerance,
                     self.error_counter.count(),
                 )
         else:


### PR DESCRIPTION
Refactors the failure strategy handler selection to make it easier to add and remove strategies. It also removes a level of nested conditionals, which makes the code easier to reason about.

Finally, when there _is_ a method to handle the error, but the error tolerance is not yet reached, a debug logging call is added to signal that we received the error, but did not take action.