### PR TITLE
Add SSL verification configuration

### DIFF
--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -62,6 +62,8 @@ class ZabbixSettings(ConfigBaseModel):
         description="The timeout in seconds for HTTP requests to Zabbix.",
         ge=0,
     )
+    verify_ssl: Union[bool, str] = True
+    """Path to a CA bundle file or `True` to use the system's CA bundle. False to disable SSL verification."""
 
     tags_prefix: str = "zac_"
     managed_inventory: List[str] = []

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -720,6 +720,7 @@ class ZabbixUpdater(BaseProcess):
             self.config.url,
             timeout=self.config.timeout,  # timeout for connect AND read
             read_only=self.config.dryrun,  # prevent accidental changes
+            verify_ssl=self.config.verify_ssl,
         )
 
         self.login()


### PR DESCRIPTION
Adds the ability to enable/disable SSL verification, as well as provide a path to a custom CA bundle in the configuration file.

```toml
[zabbix]
verify_ssl = "/path/to/certs.pem" # or True/False
```

The default value is `True`, which reflects the current client defaults.