### PR TITLE
Use `Path` type for `zabbix.verify_ssl`, fix `timeout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `disable_duration > 0`: Disable the source collector for a set duration.
   - `disable_duration < 0`: Never disable, never increase the update interval.
   - `exit_on_error` takes precedence over `disable_duration`. If `exit_on_error` is set to `true`, the source collector will exit on error regardless of the `disable_duration` setting.
+- `zabbix.verify_ssl` option to control SSL certificate verification for Zabbix API connections. Can be a boolean or a path to a CA bundle. Defaults to `true`.
 
 ### Changed
 
 - The default value of `exit_on_error` for source collectors is now `false`.
 - The default value of `disable_duration` for source collectors is now `0`. This means that the source collector will use exponential backoff to increase the update interval on error.
+
+### Fixed
+
+- `zabbix.timeout` option now correctly disables timeout when set to `0` instead of setting a timeout of 0 seconds, thereby causing instant connection timeouts.
 
 ## [0.2.0](https://github.com/unioslo/zabbix-auto-config/releases/tag/zac-v0.2.0)
 

--- a/zabbix_auto_config/errcount.py
+++ b/zabbix_auto_config/errcount.py
@@ -39,7 +39,6 @@ class Error:
     def __lt__(self, other: "Error") -> bool:
         return self.timestamp < other.timestamp
 
-    @compare
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):
             return False
@@ -57,11 +56,8 @@ class Error:
     def __ge__(self, other: "Error") -> bool:
         return self.timestamp >= other.timestamp
 
-    @compare
     def __ne__(self, other: object) -> bool:
-        if not isinstance(other, self.__class__):
-            return False
-        return self.timestamp != other.timestamp
+        return not self == other
 
 
 class RollingErrorCounter:

--- a/zabbix_auto_config/errcount.py
+++ b/zabbix_auto_config/errcount.py
@@ -40,7 +40,9 @@ class Error:
         return self.timestamp < other.timestamp
 
     @compare
-    def __eq__(self, other: "Error") -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
         return self.timestamp == other.timestamp
 
     @compare
@@ -56,7 +58,9 @@ class Error:
         return self.timestamp >= other.timestamp
 
     @compare
-    def __ne__(self, other: "Error") -> bool:
+    def __ne__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
         return self.timestamp != other.timestamp
 
 

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -62,7 +62,7 @@ class ZabbixSettings(ConfigBaseModel):
         description="The timeout in seconds for HTTP requests to Zabbix.",
         ge=0,
     )
-    verify_ssl: Union[bool, str] = True
+    verify_ssl: Union[bool, Path] = True
     """Path to a CA bundle file or `True` to use the system's CA bundle. False to disable SSL verification."""
 
     tags_prefix: str = "zac_"

--- a/zabbix_auto_config/pyzabbix/client.py
+++ b/zabbix_auto_config/pyzabbix/client.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import ssl
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
@@ -134,14 +135,17 @@ class ZabbixAPI:
         server: str = "http://localhost/zabbix",
         timeout: Optional[int] = None,
         read_only: bool = False,
-        verify_ssl: Union[str, bool] = True,
+        verify_ssl: Union[bool, Path] = True,
     ):
         """Parameters:
         server: Base URI for zabbix web interface (omitting /api_jsonrpc.php)
         timeout: optional connect and read timeout in seconds.
+        read_only: Prevent all write operations to the API.
+        verify_ssl: Verify SSL certificates. Can be a boolean or a path to a CA bundle.
+
         """
         self.timeout = timeout if timeout else None
-        self.session = self._get_client(verify_ssl=verify_ssl, timeout=timeout)
+        self.session = self._get_client(verify_ssl=verify_ssl)
         self.read_only = read_only
 
         self.auth = ""
@@ -154,17 +158,26 @@ class ZabbixAPI:
         # Attributes for properties
         self._version: Optional[Version] = None
 
-    def _get_client(
-        self, verify_ssl: Union[str, bool], timeout: Union[float, int, None] = None
-    ) -> httpx.Client:
-        kwargs: HTTPXClientKwargs = {}
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-
-        if isinstance(verify_ssl, str):
-            ctx = ssl.create_default_context(cafile=verify_ssl)
+    def _get_ssl_context(
+        self, verify_ssl: Union[bool, Path]
+    ) -> Union[ssl.SSLContext, bool]:
+        if isinstance(verify_ssl, Path):
+            if not verify_ssl.exists():
+                raise ValueError(f"CA bundle not found: {verify_ssl}")
+            if verify_ssl.is_dir():
+                ctx = ssl.create_default_context(capath=verify_ssl)
+            else:
+                ctx = ssl.create_default_context(cafile=verify_ssl)
         else:
             ctx = verify_ssl
+        return ctx
+
+    def _get_client(self, verify_ssl: Union[bool, Path]) -> httpx.Client:
+        kwargs: HTTPXClientKwargs = {}
+        if self.timeout is not None:
+            kwargs["timeout"] = self.timeout
+
+        ctx = self._get_ssl_context(verify_ssl)
 
         client = httpx.Client(
             verify=ctx,


### PR DESCRIPTION
Also fixes a bunch of minor bugs