### PR TITLE
Don't raise from ValidationError on failed CollectorConfig validation

### DIFF
--- a/zabbix_auto_config/sourcecollectors.py
+++ b/zabbix_auto_config/sourcecollectors.py
@@ -45,4 +45,4 @@ class CollectorConfig(BaseModel):
         except ValidationError as e:
             raise ZACException(
                 f"Invalid configuration for source collector {_get_collector_name(cls)!r}: {e}"
-            ) from e
+            ) from None


### PR DESCRIPTION
Raising a ZACException containing the Pydantic error message is enough information to debug the problem. Raising from the original ValidationError creates a very long stack trace containing the same Pydantic error message twice. Example:

```
Traceback (most recent call last):
  File "/home/zabbix-local-test/zabbix-auto-config/zabbix_auto_config/sourcecollectors.py", line 44, in from_kwargs
    return cls.model_validate(kwargs)
  File "/home/zabbix-local-test/zabbix-auto-config/venv/lib64/python3.9/site-packages/pydantic/main.py", line 596, in model_validate
    return cls.__pydantic_validator__.validate_python(
pydantic_core._pydantic_core.ValidationError: 2 validation errors for LDAPConfig
properties
  Set should have at least 1 item after validation, not 0 [type=too_short, input_value=[], input_type=list]
    For further information visit https://errors.pydantic.dev/2.9/v/too_short
siteadmins
  Set should have at least 1 item after validation, not 0 [type=too_short, input_value=[], input_type=list]
    For further information visit https://errors.pydantic.dev/2.9/v/too_short

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/zabbix-local-test/zabbix-mgmt/prod/zabbix_import_data/sourcecollector/ldap_windows.py", line 100, in <module>
    print_hosts(collect(**vars(args)))
  File "/home/zabbix-local-test/zabbix-mgmt/prod/zabbix_import_data/sourcecollector/ldap_windows.py", line 71, in collect
    config = LDAPConfig.from_kwargs(**kwargs)
  File "/home/zabbix-local-test/zabbix-auto-config/zabbix_auto_config/sourcecollectors.py", line 46, in from_kwargs
    raise ZACException(
zabbix_auto_config.exceptions.ZACException: Invalid configuration for source collector 'ldap_windows': 2 validation errors for LDAPConfig
properties
  Set should have at least 1 item after validation, not 0 [type=too_short, input_value=[], input_type=list]
    For further information visit https://errors.pydantic.dev/2.9/v/too_short
siteadmins
  Set should have at least 1 item after validation, not 0 [type=too_short, input_value=[], input_type=list]
    For further information visit https://errors.pydantic.dev/2.9/v/too_short
```

Too verbose.