### PR TITLE
Add XDG base dir support for config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+* XDG Base Directory support for application files (config, logs, data, etc.). The following directories are supported:
+  * `XDG_CONFIG_HOME` or `~/.config/zabbix-auto-config` for configuration files.
+
+### Changed
+
+* The application now looks in all valid config file locations for the config file. In order of preference:
+  * Current working directory (`./config.toml`)
+  * `XDG_CONFIG_HOME` or `~/.config/zabbix-auto-config/config.toml`
+
 ## 0.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For automatic linking in templates you could create the templates:
 
 ### Database
 
-The application requires a PostgreSQL database to store the state of the collected hosts. The database and tables are created automatically the first time the application runs, provided that the database connection is configured in `config.toml`:
+The application requires a PostgreSQL database to store the state of the collected hosts. The database and tables are created automatically the first time the application runs, provided that the database connection is configured in the config file:
 
 ```toml
 [zac.db]
@@ -104,6 +104,9 @@ tables = true
 hosts = "hosts"
 hosts_source = "hosts_source"
 ```
+
+> [!TIP]
+> See [Configuration](#configuration) for more info on the config file.
 
 Creation of the `zac` database requires superuser privileges. If the configured ZAC user does not have superuser privileges, the `zac` database must be created manually before running the application, and the `zac.db.init.db` option must be set to `false` in the configuration file.
 
@@ -135,16 +138,22 @@ When installing from source, installing in editable mode is recommended, as it a
 
 ## Configuration
 
-ZAC automatically sources `config.toml` from the current working directory when starting up. A sample configuration file is provided in the repository: [config.sample.toml](./config.sample.toml).
+ZAC tries to load a config file on startup in the following order:
+
+1. `./config.toml`
+2. `XDG_CONFIG_HOME` or `~/.config/zabbix-auto-config/config.toml`
+
+A sample configuration file is provided in the repository: [config.sample.toml](./config.sample.toml). Move this file to one of the locations above and modify it to suit your environment.
 
 ### Mock environment
 
 A ZAC environment with a set of mock source collectors, host modifiers, and mapping files is included in the [examples](./examples) directory. The [sample config file](./config.sample.toml) comes pre-configured with these activated.
 
-Rename the sample config file to `config.toml` to use it:
+Rename the sample config file to `config.toml` (and optionally move it to the configuration directory) to use it:
 
 ```bash
-mv config.sample.toml config.toml
+mkdir -p ~/.config/zabbix-auto-config
+mv config.sample.toml ~/.config/zabbix-auto-config/config.toml
 ```
 
 ## Running

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "tomli>=2.0.0",
     "packaging>=23.2",
     "typing_extensions>=4.12.0",
+    "platformdirs>=4.3.7",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 
 [[package]]
@@ -199,6 +200,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/2d/7d512a3913d60623e7eb945c6d1b4f0bddf1d0b7ada5225274c87e5b53d1/platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351", size = 21291 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/45/59578566b3275b8fd9157885918fcd0c4d74162928a5310926887b856a51/platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94", size = 18499 },
 ]
 
 [[package]]
@@ -463,6 +473,7 @@ dependencies = [
     { name = "httpx" },
     { name = "multiprocessing-logging" },
     { name = "packaging" },
+    { name = "platformdirs" },
     { name = "psycopg2" },
     { name = "pydantic" },
     { name = "tomli" },
@@ -488,6 +499,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "multiprocessing-logging", specifier = ">=0.3.1" },
     { name = "packaging", specifier = ">=23.2" },
+    { name = "platformdirs", specifier = ">=4.3.7" },
     { name = "psycopg2", specifier = ">=2.9.5" },
     { name = "pydantic", specifier = ">=2.9.1" },
     { name = "tomli", specifier = ">=2.0.0" },

--- a/zabbix_auto_config/__init__.py
+++ b/zabbix_auto_config/__init__.py
@@ -12,7 +12,6 @@ import time
 from typing import List
 
 import multiprocessing_logging
-import tomli
 
 from zabbix_auto_config import models
 from zabbix_auto_config import processing
@@ -21,6 +20,7 @@ from zabbix_auto_config._types import HostModifier
 from zabbix_auto_config._types import HostModifierModule
 from zabbix_auto_config._types import SourceCollector
 from zabbix_auto_config._types import SourceCollectorModule
+from zabbix_auto_config.config import get_config
 from zabbix_auto_config.db import init_db
 from zabbix_auto_config.health import write_health
 from zabbix_auto_config.state import get_manager
@@ -92,16 +92,6 @@ def get_host_modifiers(modifier_dir: str) -> List[HostModifier]:
         ", ".join([repr(modifier.name) for modifier in host_modifiers]),
     )
     return host_modifiers
-
-
-def get_config() -> models.Settings:
-    cwd = os.getcwd()
-    config_file = os.path.join(cwd, "config.toml")
-    with open(config_file) as f:
-        content = f.read()
-    config_dict = tomli.loads(content)
-    config = models.Settings(**config_dict)
-    return config
 
 
 def log_process_status(processes: List[processing.BaseProcess]) -> None:

--- a/zabbix_auto_config/config.py
+++ b/zabbix_auto_config/config.py
@@ -1,0 +1,42 @@
+"""ZAC configuration module."""
+# TODO: move `models.Settings` and its dependencies to this module.
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import tomli
+
+from zabbix_auto_config import models
+from zabbix_auto_config.dirs import CONFIG_FILE_DEFAULT
+from zabbix_auto_config.dirs import CONFIG_FILENAME
+
+logger = logging.getLogger(__name__)
+
+
+CONFIG_PATHS = [
+    Path(".") / CONFIG_FILENAME,
+    CONFIG_FILE_DEFAULT,
+]
+
+
+def get_config() -> models.Settings:
+    """Load the ZAC configuration from the first available configuration file."""
+    for path in CONFIG_PATHS:
+        try:
+            return _load_config(path)
+        except FileNotFoundError:
+            logger.debug("No configuration file found in %s", path)
+        except Exception as e:  # catch-all for unexpected errors
+            logger.error("Error loading configuration from %s: %s", path, e)
+    raise FileNotFoundError(f"No valid configuration file found in {CONFIG_PATHS}")
+
+
+def _load_config(config_file: Path) -> models.Settings:
+    """Load a ZAC configuration file from the given location."""
+    with open(config_file) as f:
+        content = f.read()
+    config_dict = tomli.loads(content)
+    config = models.Settings(**config_dict)
+    return config

--- a/zabbix_auto_config/dirs.py
+++ b/zabbix_auto_config/dirs.py
@@ -1,0 +1,11 @@
+"""Directories used by the application."""
+
+from __future__ import annotations
+
+from platformdirs import PlatformDirs
+
+pdirs = PlatformDirs("zabbix-auto-config", "unioslo")
+
+CONFIG_DIR = pdirs.user_config_path
+CONFIG_FILENAME = "config.toml"
+CONFIG_FILE_DEFAULT = CONFIG_DIR / "config.toml"


### PR DESCRIPTION
Adds support for loading the config file from `XDG_CONFIG_HOME` via platformdirs.