### PR TITLE
Add Typer CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "packaging>=23.2",
     "typing_extensions>=4.12.0",
     "platformdirs>=4.3.7",
+    "typer>=0.15.2",
 ]
 
 
@@ -49,7 +50,7 @@ test = [
 Source = "https://github.com/unioslo/zabbix-auto-config"
 
 [project.scripts]
-zac = "zabbix_auto_config:main"
+zac = "zabbix_auto_config.__main__:main"
 
 [tool.hatch.version]
 path = "zabbix_auto_config/__about__.py"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,11 +101,20 @@ def invalid_hosts():
 
 
 @pytest.fixture(scope="function")
-def sample_config():
-    with open(
-        os.path.dirname(os.path.dirname(__file__)) + "/config.sample.toml"
-    ) as config:
-        yield config.read()
+def sample_config_path(tmp_path: Path):
+    """Creates a sample config file for testing."""
+    # Read from the sample config file in the repo root
+    sample_config_path = Path(__file__).parent.parent / "config.sample.toml"
+
+    # Create a temp file with the contents of the sample config
+    p = tmp_path / "config.toml"
+    p.write_text(sample_config_path.read_text())
+    yield p
+
+
+@pytest.fixture(scope="function")
+def sample_config(sample_config_path: Path):
+    yield sample_config_path.read_text()
 
 
 @pytest.fixture(name="config")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+BaseModelT = TypeVar("BaseModelT", bound=BaseModel)
+
+
+@contextmanager
+def disable_assignment_validation(
+    model: BaseModelT,
+) -> Generator[BaseModelT, None, None]:
+    """Temporarily disable `validate_assignment` for a Pydantic model."""
+    orig = model.model_config.get("validate_assignment")
+    model.model_config["validate_assignment"] = False
+    try:
+        yield model
+    finally:
+        # Revert to original value (if any) or remove the key
+        if orig is not None:
+            model.model_config["validate_assignment"] = orig
+        else:
+            model.model_config.pop("validate_assignment", None)

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -401,6 +413,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -458,6 +479,21 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.15.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/6f/3991f0f1c7fcb2df31aef28e0594d8d54b05393a0e4e34c65e475c2a5d41/typer-0.15.2.tar.gz", hash = "sha256:ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5", size = 100711 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl", hash = "sha256:46a499c6107d645a9c13f7ee46c5d5096cae6f5fc57dd11eccbbb9ae3e44ddfc", size = 45061 },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
@@ -477,6 +513,7 @@ dependencies = [
     { name = "psycopg2" },
     { name = "pydantic" },
     { name = "tomli" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
 
@@ -503,6 +540,7 @@ requires-dist = [
     { name = "psycopg2", specifier = ">=2.9.5" },
     { name = "pydantic", specifier = ">=2.9.1" },
     { name = "tomli", specifier = ">=2.0.0" },
+    { name = "typer", specifier = ">=0.15.2" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
 ]
 

--- a/zabbix_auto_config/__init__.py
+++ b/zabbix_auto_config/__init__.py
@@ -29,7 +29,7 @@ from zabbix_auto_config.db import init_db
 from zabbix_auto_config.health import write_health
 from zabbix_auto_config.state import get_manager
 
-app = typer.Typer(add_completion=False)
+app = typer.Typer(add_completion=False, pretty_exceptions_enable=False)
 
 
 def get_source_collectors(config: models.Settings) -> List[SourceCollector]:

--- a/zabbix_auto_config/__main__.py
+++ b/zabbix_auto_config/__main__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from zabbix_auto_config import run
+
+
+def main() -> None:
+    run()
+
+
+if __name__ == "__main__":
+    main()

--- a/zabbix_auto_config/config.py
+++ b/zabbix_auto_config/config.py
@@ -4,13 +4,21 @@
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
+from typing import Optional
 
-import tomli
+# Use standard library for Python 3.11+, fallback to tomli for older versions
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from zabbix_auto_config import models
 from zabbix_auto_config.dirs import CONFIG_FILE_DEFAULT
 from zabbix_auto_config.dirs import CONFIG_FILENAME
+from zabbix_auto_config.exceptions import ConfigFileNotFoundError
+from zabbix_auto_config.exceptions import ConfigValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -21,22 +29,41 @@ CONFIG_PATHS = [
 ]
 
 
-def get_config() -> models.Settings:
+def get_config(path: Optional[Path] = None) -> models.Settings:
     """Load the ZAC configuration from the first available configuration file."""
+    # We have a specific path, load it
+    if path:
+        return load_config(path)
+
+    # Fallback on finding a config file
     for path in CONFIG_PATHS:
         try:
-            return _load_config(path)
-        except FileNotFoundError:
-            logger.debug("No configuration file found in %s", path)
-        except Exception as e:  # catch-all for unexpected errors
-            logger.error("Error loading configuration from %s: %s", path, e)
+            return load_config(path)
+        except ConfigFileNotFoundError as e:
+            logger.debug(e)
+        except ConfigValidationError as e:
+            logger.error(e)
     raise FileNotFoundError(f"No valid configuration file found in {CONFIG_PATHS}")
+
+
+def load_config(config_file: Path) -> models.Settings:
+    """Load a ZAC configuration file from the given location."""
+    try:
+        return _load_config(config_file)
+    except FileNotFoundError as e:
+        raise ConfigFileNotFoundError(
+            f"Configuration file {config_file} not found."
+        ) from e
+    except Exception as e:  # catch-all for unexpected errors
+        raise ConfigValidationError(
+            f"Error loading configuration from {config_file}: {e}"
+        ) from e
 
 
 def _load_config(config_file: Path) -> models.Settings:
     """Load a ZAC configuration file from the given location."""
-    with open(config_file) as f:
-        content = f.read()
-    config_dict = tomli.loads(content)
+    with open(config_file, "rb") as f:
+        config_dict = tomllib.load(f)
     config = models.Settings(**config_dict)
+    config.config_path = config_file
     return config

--- a/zabbix_auto_config/exceptions.py
+++ b/zabbix_auto_config/exceptions.py
@@ -89,3 +89,15 @@ class SourceCollectorError(ZACException):
 
 class SourceCollectorTypeError(SourceCollectorError):
     """Source collector function returned wrong type."""
+
+
+class ConfigError(ZACException):
+    """Exceptions related to configuration."""
+
+
+class ConfigFileNotFoundError(ConfigError):
+    """Configuration file not found."""
+
+
+class ConfigValidationError(ConfigError):
+    """Configuration validation error."""

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -30,10 +30,20 @@ from zabbix_auto_config import utils
 # TODO: Models aren't validated when making changes to a set/list. Why? How to handle?
 
 
-class ConfigBaseModel(PydanticBaseModel, extra="ignore"):
+class ConfigBaseModel(PydanticBaseModel):
     """Base class for all config models. Warns if unknown fields are passed in."""
 
     # https://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally
+
+    model_config = ConfigDict(
+        # We support overriding values via CLI args, so we want to be able
+        # to validate them using the same validation logic we use for config
+        # values loaded from files.
+        validate_assignment=True,
+        # Ignore extra values by default and emit warning if present.
+        # Subclasses may override this to allow extra values.
+        extra="ignore",
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -354,7 +364,7 @@ class FailureStrategy(str, Enum):
         return self in {FailureStrategy.EXIT, FailureStrategy.DISABLE}
 
 
-class SourceCollectorSettings(ConfigBaseModel, extra="allow"):
+class SourceCollectorSettings(ConfigBaseModel):
     module_name: str
     update_interval: int = Field(..., ge=0)
     error_tolerance: int = Field(
@@ -388,6 +398,13 @@ class SourceCollectorSettings(ConfigBaseModel, extra="allow"):
         default=3600,
         description="Maximum backoff duration in seconds.",
         ge=0,
+    )
+
+    model_config = ConfigDict(
+        # Validators cause infinte recursion if assignment validation is enabled.
+        # TODO: fix
+        validate_assignment=False,
+        extra="allow",
     )
 
     @property

--- a/zabbix_auto_config/models.py
+++ b/zabbix_auto_config/models.py
@@ -492,6 +492,10 @@ class Settings(ConfigBaseModel):
     zabbix: ZabbixSettings
     source_collectors: Dict[str, SourceCollectorSettings]
 
+    config_path: Optional[Path] = Field(
+        default=None, description="Path the config was loaded from.", exclude=True
+    )
+
 
 class Interface(BaseModel):
     details: Optional[Dict[str, Union[int, str]]] = {}


### PR DESCRIPTION
Adds a CLI interface to ZAC for overriding some common config options, or specifying a new config path entirely.

```
❯ zac --help
                                                                                                    
 Usage: zac [OPTIONS]                                                                               
                                                                                                    
 Run Zabbix-auto-config.                                                                            
                                                                                                    
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
│ --failsafe  -F      INTEGER  Maximum number of hosts to change.                                  │
│ --dryrun    -D               Dry run mode.                                                       │
│ --config    -C      PATH     Path to config file.                                                │
│ --help                       Show this message and exit.                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯

```

This should aid in development and in cases where users want to specify a custom config location when running ZAC.

## Dependencies

This PR adds [Typer](https://pypi.org/project/typer/) as a dependency, which pulls in [Shellingham](https://pypi.org/project/shellingham/) and [Click](https://pypi.org/project/click/). I deem this a worthwhile tradeoff over using argparse.