### PR TITLE
Add cron schedule support for garbage collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,13 +626,17 @@ To enable garbage collection, add the following to your config:
 enabled = True
 ```
 
-By default, the garbage collector runs every 24 hours. This can be adjusted with the `update_interval` option:
+By default, the garbage collector runs immediately on startup, then every 24 hours. You can replace this with a cron schedule:
 
 ```toml
 [zac.process.garbage_collector]
-update_interval = 3600 # Run every hour
+schedule = "0 0 * * *" # every day at midnight
 enabled = True
 ```
+
+When a schedule is set, the garbage collector skips the immediate startup run and fires only when the cron expression matches.
+
+All cron expressions supported by [croniter](https://pypi.org/project/croniter/) are supported.
 
 
 #### Maintenance cleanup

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -130,7 +130,7 @@ update_interval = 60
 #       - Delete maintenances if all hosts are disabled (optional)
 #   - Delete hosts that have been disabled for a long time (optional)
 enabled = false
-update_interval = 86400 # every 24 hours
+schedule = "0 0 * * *" # every day at midnight
 
 [zac.process.garbage_collector.maintenances]
 enabled = true # Enabled by default if GC is enabled.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "platformdirs>=4.3.7",
     "typer>=0.15.2",
     "structlog>=25.4.0",
+    "croniter>=6.2.2",
 ]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -236,8 +236,9 @@ def test_load_config_from_path(sample_config_path: Path) -> None:
                     "hostgroup_updater": {"update_interval": 60},
                     "template_updater": {"update_interval": 60},
                     "garbage_collector": {
-                        "update_interval": 86400,
+                        "update_interval": 60,
                         "enabled": False,
+                        "schedule": "0 0 * * *",
                         "hosts": {"enabled": True, "retention_days": 90},
                         "maintenances": {"enabled": True, "delete_empty": False},
                     },
@@ -730,7 +731,7 @@ def test_dbtablesettings_empty_name() -> None:
         )
 
 
-def test_garbagecollectorsettings_deprecated_field():
+def test_garbagecollectorsettings_deprecated_maintenances_delete_empty():
     """Test that garbage collector settings handling deprecated field correctly."""
     # Setting only deprecated field assigns it to new field in subconfig
     settings = ZacSettings(
@@ -777,3 +778,36 @@ def test_garbagecollectorsettings_deprecated_field():
         ),
     )
     assert settings.process.garbage_collector.maintenances.delete_empty is True
+
+
+def test_garbagecollectorsettings_schedule_and_update_interval():
+    """Test that garbage collector settings handles schedule and update_interval correctly."""
+    # Setting schedule uses schedule
+    settings = GarbageCollectorSettings(
+        enabled=False,
+        schedule="0 0 * * *",
+    )
+    assert settings.schedule == snapshot("0 0 * * *")
+    assert settings.update_interval == snapshot(60)
+
+    # Setting update_interval unsets schedule
+    settings = GarbageCollectorSettings(
+        update_interval=86400,
+        enabled=False,
+    )
+    assert settings.schedule == snapshot(None)
+    assert settings.update_interval == snapshot(86400)
+
+    # Setting both uses schedule
+    settings = GarbageCollectorSettings(
+        update_interval=86400,
+        enabled=False,
+        schedule="0 0 * * *",
+    )
+    assert settings.schedule == snapshot("0 0 * * *")
+    assert settings.update_interval == snapshot(86400)
+
+    # Uses schedule by default
+    settings = GarbageCollectorSettings()
+    assert settings.schedule == snapshot("0 0 * * *")
+    assert settings.update_interval == snapshot(60)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 
 [[package]]
@@ -72,6 +72,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
 ]
 
 [[package]]
@@ -412,6 +424,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "rich"
 version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -457,6 +481,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -568,6 +601,7 @@ wheels = [
 name = "zabbix-auto-config"
 source = { editable = "." }
 dependencies = [
+    { name = "croniter" },
     { name = "httpx" },
     { name = "multiprocessing-logging" },
     { name = "packaging" },
@@ -598,6 +632,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "croniter", specifier = ">=6.2.2" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "multiprocessing-logging", specifier = ">=0.3.1" },
     { name = "packaging", specifier = ">=23.2" },

--- a/zabbix_auto_config/config.py
+++ b/zabbix_auto_config/config.py
@@ -210,7 +210,7 @@ class GarbageCollectorSettings(ProcessSettings):
 
     @model_validator(mode="after")
     def validate_schedule_and_update_interval(self) -> Self:
-        """Unsets schedule if update_interval is set."""
+        """Unsets schedule if _only_ update_interval is set."""
         if (
             "update_interval" in self.model_fields_set
             and "schedule" not in self.model_fields_set

--- a/zabbix_auto_config/config.py
+++ b/zabbix_auto_config/config.py
@@ -181,6 +181,10 @@ class GarbageCollectorSettings(ProcessSettings):
     enabled: bool = Field(
         default=False, description="Enable/disable all garbage collection features."
     )
+    schedule: Optional[str] = Field(
+        default="0 0 * * *",
+        description="Cron schedule for running the garbage collector.",
+    )
 
     hosts: HostGcSettings = Field(default_factory=HostGcSettings)
     maintenances: MaintenanceGcSettings = Field(default_factory=MaintenanceGcSettings)
@@ -194,8 +198,7 @@ class GarbageCollectorSettings(ProcessSettings):
     )
 
     @model_validator(mode="after")
-    def validate_model(self) -> Self:
-        # Handle deprecated fields
+    def validate_deprecated_field_delete_empty_maintenance(self) -> Self:
         if (
             "delete_empty_maintenance" in self.model_fields_set
             and "delete_empty" not in self.maintenances.model_fields_set
@@ -203,6 +206,16 @@ class GarbageCollectorSettings(ProcessSettings):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
                 self.maintenances.delete_empty = self.delete_empty_maintenance
+        return self
+
+    @model_validator(mode="after")
+    def validate_schedule_and_update_interval(self) -> Self:
+        """Unsets schedule if update_interval is set."""
+        if (
+            "update_interval" in self.model_fields_set
+            and "schedule" not in self.model_fields_set
+        ):
+            self.schedule = None
         return self
 
 
@@ -214,7 +227,7 @@ class ProcessesSettings(ConfigBaseModel):
     hostgroup_updater: HostGroupUpdaterSettings = HostGroupUpdaterSettings()
     template_updater: TemplateUpdaterSettings = TemplateUpdaterSettings()
     garbage_collector: GarbageCollectorSettings = GarbageCollectorSettings(
-        update_interval=86400  # every 24 hours
+        schedule="0 0 * * *"  # every 24 hours (cron format)
     )
 
 

--- a/zabbix_auto_config/cron.py
+++ b/zabbix_auto_config/cron.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import datetime
+from typing import Optional
+
+from croniter import croniter
+
+
+def get_iter(
+    schedule: str, start_time: Optional[datetime.datetime] = None
+) -> croniter[datetime.datetime]:
+    """Get a croniter iterator for a given schedule and start time."""
+    if start_time is None:
+        start_time = datetime.datetime.now()
+    try:
+        return croniter(schedule, start_time, datetime.datetime)
+    except (ValueError, KeyError) as e:
+        raise ValueError(f"Invalid cron schedule: {e}") from e

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -30,6 +30,7 @@ from pydantic import ValidationError
 from typing_extensions import override
 
 from zabbix_auto_config import compat
+from zabbix_auto_config import cron
 from zabbix_auto_config import db
 from zabbix_auto_config import models
 from zabbix_auto_config import utils
@@ -93,6 +94,10 @@ class BaseProcess(multiprocessing.Process):
             logger.error("Unable to connect to database.")
             raise ZACException(*e.args) from e
 
+    def get_next_update(self) -> datetime:
+        """Get the time the process should run next."""
+        return datetime.now() + timedelta(seconds=self.update_interval)
+
     def run(self) -> None:
         logger.debug("Process starting")
 
@@ -109,9 +114,7 @@ class BaseProcess(multiprocessing.Process):
                     continue
 
                 start_time = datetime.now()
-                self.next_update = datetime.now() + timedelta(
-                    seconds=self.update_interval
-                )
+                self.next_update = self.get_next_update()
 
                 try:
                     self.work()
@@ -856,6 +859,19 @@ class ZabbixGarbageCollector(ZabbixUpdater):
             self.config.zac.db.tables.hosts_pending_deletion
         )
         self.gc_config = self.config.zac.process.garbage_collector
+        if self.gc_config.schedule:
+            self.schedule = cron.get_iter(self.gc_config.schedule)
+            # Explictly set next update time so that BaseProcess.run()
+            # is aware of the schedule. Otherwise we would run on startup!
+            self.next_update = self.get_next_update()
+        else:
+            self.schedule = None
+
+    @override
+    def get_next_update(self) -> datetime:
+        if self.schedule:
+            return self.schedule.get_next()
+        return super().get_next_update()
 
     @override
     def do_update(self) -> None:

--- a/zabbix_auto_config/test_cron.py
+++ b/zabbix_auto_config/test_cron.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from zabbix_auto_config.cron import get_iter
+
+START_TIME = datetime(2021, 1, 1, 0, 0, 0)  # Friday
+
+
+@pytest.mark.parametrize(
+    "schedule,values",
+    [
+        (
+            "* * * * *",  # every minute
+            [
+                datetime(2021, 1, 1, 0, 1, 0),
+                datetime(2021, 1, 1, 0, 2, 0),
+                datetime(2021, 1, 1, 0, 3, 0),
+                datetime(2021, 1, 1, 0, 4, 0),
+                datetime(2021, 1, 1, 0, 5, 0),
+            ],
+        ),
+        (
+            "0 * * * *",  # every hour
+            [
+                datetime(2021, 1, 1, 1, 0, 0),
+                datetime(2021, 1, 1, 2, 0, 0),
+                datetime(2021, 1, 1, 3, 0, 0),
+                datetime(2021, 1, 1, 4, 0, 0),
+                datetime(2021, 1, 1, 5, 0, 0),
+            ],
+        ),
+        (
+            "*/15 * * * *",  # every 15 minutes
+            [
+                datetime(2021, 1, 1, 0, 15, 0),
+                datetime(2021, 1, 1, 0, 30, 0),
+                datetime(2021, 1, 1, 0, 45, 0),
+                datetime(2021, 1, 1, 1, 0, 0),
+                datetime(2021, 1, 1, 1, 15, 0),
+            ],
+        ),
+        (
+            "5 4 * * *",  # daily at 04:05
+            [
+                datetime(2021, 1, 1, 4, 5, 0),
+                datetime(2021, 1, 2, 4, 5, 0),
+                datetime(2021, 1, 3, 4, 5, 0),
+                datetime(2021, 1, 4, 4, 5, 0),
+                datetime(2021, 1, 5, 4, 5, 0),
+            ],
+        ),
+        (
+            "0 0 * * *",  # daily at midnight
+            [
+                datetime(2021, 1, 2, 0, 0, 0),
+                datetime(2021, 1, 3, 0, 0, 0),
+                datetime(2021, 1, 4, 0, 0, 0),
+                datetime(2021, 1, 5, 0, 0, 0),
+                datetime(2021, 1, 6, 0, 0, 0),
+            ],
+        ),
+        (
+            "0 9 * * 1-5",  # weekdays at 09:00; 2021-01-01 is a Friday
+            [
+                datetime(2021, 1, 1, 9, 0, 0),  # Friday
+                datetime(2021, 1, 4, 9, 0, 0),  # Monday
+                datetime(2021, 1, 5, 9, 0, 0),  # Tuesday
+                datetime(2021, 1, 6, 9, 0, 0),  # Wednesday
+                datetime(2021, 1, 7, 9, 0, 0),  # Thursday
+            ],
+        ),
+        (
+            "30 6 * * 0",  # every Sunday at 06:30; next Sunday from start is 2021-01-03
+            [
+                datetime(2021, 1, 3, 6, 30, 0),
+                datetime(2021, 1, 10, 6, 30, 0),
+                datetime(2021, 1, 17, 6, 30, 0),
+                datetime(2021, 1, 24, 6, 30, 0),
+                datetime(2021, 1, 31, 6, 30, 0),
+            ],
+        ),
+        (
+            "0 0 1 * *",  # first day of each month at midnight
+            [
+                datetime(2021, 2, 1, 0, 0, 0),
+                datetime(2021, 3, 1, 0, 0, 0),
+                datetime(2021, 4, 1, 0, 0, 0),
+                datetime(2021, 5, 1, 0, 0, 0),
+                datetime(2021, 6, 1, 0, 0, 0),
+            ],
+        ),
+    ],
+)
+def test_get_iter(schedule: str, values: list[datetime]):
+    citer = get_iter(schedule, start_time=START_TIME)
+    for expected in values:
+        assert citer.get_next() == expected
+
+
+@pytest.mark.parametrize(
+    "schedule",
+    [
+        "not a cron",
+        "* * * *",  # too few fields
+        "60 * * * *",  # minute out of range
+        "* 25 * * *",  # hour out of range
+    ],
+)
+def test_get_iter_invalid(schedule: str):
+    with pytest.raises(ValueError, match="Invalid cron schedule"):
+        _ = get_iter(schedule)


### PR DESCRIPTION
This PR adds the ability to specify a cron schedule for the garbage collection process instead of an update interval. This enables garbage collection to run at specific times, instead of just every N seconds.