### PR TITLE
Fix source collector error logging, add exception formatter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ use_mp_handler = false
 enabled = true
 level = "INFO"
 format = "text"
+exception_formatter = "rich" # rich | plain
 
 [zac.logging.file]
 enabled = true

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -74,21 +74,14 @@ use_mp_handler = false
 
 # Settings for the console logger.
 [zac.logging.console]
-# Enable/disable the console logger.
 enabled = true
-
-# Log level for the console logger.
 level = "INFO"
-
-# Log format for the console logger.
 format = "text"
+exception_formatter = "rich" # rich | plain
 
 # Settings for the file logger.
 [zac.logging.file]
-# Enable/disable the file logger.
 enabled = true
-
-# Log level for the file logger.
 level = "INFO"
 
 # Log format for the file logger.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -217,7 +217,12 @@ def test_load_config_from_path(sample_config_path: Path) -> None:
                     "init": {"db": True, "tables": True},
                 },
                 "logging": {
-                    "console": {"enabled": True, "format": "text", "level": "INFO"},
+                    "console": {
+                        "enabled": True,
+                        "format": "text",
+                        "level": "INFO",
+                        "exception_formatter": "rich",
+                    },
                     "file": {
                         "enabled": True,
                         "format": "json",
@@ -417,7 +422,8 @@ def test_logging_settings_log_level_serialize() -> None:
   "console": {
     "enabled": true,
     "format": "text",
-    "level": "INFO"
+    "level": "INFO",
+    "exception_formatter": "rich"
   },
   "file": {
     "enabled": true,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -110,7 +110,7 @@ def test_log_exceptions_before_processing(config: Settings) -> None:
         except ZeroDivisionError:
             logger.exception("An error occurred")
         assert len(log_output) == 1
-        del log_output[0]["timestamp"]
+        log_output[0].pop("timestamp", None)  # remove timestamp if present
 
         # Before processing, we should still have exc_info=True
         assert log_output[0] == snapshot(

--- a/zabbix_auto_config/config.py
+++ b/zabbix_auto_config/config.py
@@ -10,6 +10,7 @@ import warnings
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from typing import Literal
 from typing import Optional
 from typing import Union
 
@@ -407,6 +408,13 @@ class ConsoleLoggerConfig(LoggerConfigBase):
     format: LoggerFormat = Field(
         default=LoggerFormat.TEXT,
         description="The format of the logger output.",
+    )
+    exception_formatter: Literal["rich", "plain"] = Field(
+        default="rich",
+        description=(
+            "The formatter to use for exceptions in the console logger. "
+            "`rich` uses rich's pretty traceback rendering, while `plain` uses structlog's default exception rendering. "
+        ),
     )
 
 

--- a/zabbix_auto_config/failsafe.py
+++ b/zabbix_auto_config/failsafe.py
@@ -23,12 +23,7 @@ def check_failsafe(config: Settings, to_add: list[str], to_remove: list[str]) ->
     # Failsafe OK file validation failed
     # We must write the hosts to add/remove and raise an exception
     write_failsafe_hosts(config.zac, to_add, to_remove)
-    logger.warning(
-        "Too many hosts to change (failsafe=%d). Remove: %d, Add: %d. Aborting",
-        failsafe,
-        len(to_remove),
-        len(to_add),
-    )
+
     raise FailsafeError(to_add, to_remove)
 
 

--- a/zabbix_auto_config/log.py
+++ b/zabbix_auto_config/log.py
@@ -10,6 +10,7 @@ import structlog
 from structlog.dev import Column
 from structlog.typing import EventDict
 
+from zabbix_auto_config.config import ConsoleLoggerConfig
 from zabbix_auto_config.config import FileLoggerConfig
 from zabbix_auto_config.config import LoggerConfigBase
 from zabbix_auto_config.config import Settings
@@ -53,9 +54,17 @@ class ZacConsoleRenderer(structlog.dev.ConsoleRenderer):
             )
 
     @classmethod
-    def create(cls) -> ZacConsoleRenderer:
+    def create(cls, config: ConsoleLoggerConfig) -> ZacConsoleRenderer:
         """Create a new instance of the ZacConsoleRenderer."""
-        instance = cls(colors=True, sort_keys=False)
+        if config.exception_formatter == "rich":
+            exc_fmt = structlog.dev.rich_traceback
+        else:
+            exc_fmt = structlog.dev.plain_traceback
+        instance = cls(
+            colors=True,
+            sort_keys=False,
+            exception_formatter=exc_fmt,
+        )
         instance.add_process_name_formatter()
         return instance
 
@@ -141,13 +150,14 @@ def configure_logging(config: Settings) -> None:
                 "()": structlog.stdlib.ProcessorFormatter,
                 "processors": [
                     structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-                    ZacConsoleRenderer.create(),
+                    ZacConsoleRenderer.create(config.zac.logging.console),
                 ],
                 "foreign_pre_chain": pre_chain,
             },
             "file": {
                 "()": structlog.stdlib.ProcessorFormatter,
                 "processors": [
+                    timestamper,
                     structlog.processors.dict_tracebacks,
                     structlog.stdlib.ProcessorFormatter.remove_processors_meta,
                     structlog.processors.JSONRenderer(),
@@ -188,7 +198,6 @@ def configure_logging(config: Settings) -> None:
         processors=[
             structlog.stdlib.add_log_level,
             structlog.stdlib.PositionalArgumentsFormatter(),
-            timestamper,
             structlog.processors.CallsiteParameterAdder(
                 parameters=[structlog.processors.CallsiteParameter.PROCESS_NAME]
             ),

--- a/zabbix_auto_config/processing.py
+++ b/zabbix_auto_config/processing.py
@@ -260,9 +260,7 @@ class SourceCollectorProcess(BaseProcess):
         try:
             self.collect()
         except Exception as e:
-            logger.exception(
-                "Failed to collect from source", error=str(e), source=self.name
-            )
+            logger.error("Source collector exception", error=str(e), source=self.name)
             self.handle_error(e)
         else:
             self.handle_success()
@@ -318,7 +316,7 @@ class SourceCollectorProcess(BaseProcess):
                 handler()
             else:
                 logger.debug(
-                    "Source has not reached error tolerance of. Keeping it enabled",
+                    "Source has not reached error tolerance. Keeping it enabled",
                     error_tolerance=self.settings.error_tolerance,
                     count=self.error_counter.count(),
                 )


### PR DESCRIPTION
This PR removes duplicate source collector exception logging, adds option to select exception formatter, and removes timestamps from console logs.