### PR TITLE
Use basedpyright, fix linting errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
 
 
 [dependency-groups]
-dev = [{ include-group = "test" }]
+dev = [{ include-group = "test" }, { include-group = "lint" }]
+lint = ["basedpyright>=1.39.8", "ruff>=0.12.5"]
 test = [
     "pytest>=9.0.3",
     "pytest-timeout>=2.2.0",
@@ -75,8 +76,27 @@ packages = ["zabbix_auto_config"]
 [tool.inline-snapshot]
 format-command = "ruff format --stdin-filename {filename}"
 
-[tool.pyright]
+[tool.basedpyright]
 pythonVersion = "3.11"
+typeCheckingMode = "recommended"
+reportUnannotatedClassAttribute = "hint"
+reportUnusedCallResult = "hint"
+reportImplicitOverride = "hint"
+reportImportCycles = "hint"
+
+# When working with pydantic before-validators, we have no choice
+# but to use and interact with `Any`-typed values.
+reportExplicitAny = false
+reportAny = false
+
+executionEnvironments = [
+    { root = "zabbix_auto_config" },
+    # inline-snapshot does not generate MacroName NewType annotations
+    # for MacroIdentity.name fields, despite 0.32.6 claiming to do so:
+    # https://15r10nk.github.io/inline-snapshot/latest/changelog/#exec-1--0326-2026-04-10
+    { root = "tests/test_macros.py", reportPrivateUsage = false, reportArgumentType = false },
+    { root = "tests", reportPrivateUsage = false },
+]
 
 [tool.ruff]
 # Same as Black.

--- a/uv.lock
+++ b/uv.lock
@@ -44,6 +44,18 @@ wheels = [
 ]
 
 [[package]]
+name = "basedpyright"
+version = "1.39.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/62/8550c75850b2185df984d1de437b4805b039ba856cacbee2966236203133/basedpyright-1.39.8.tar.gz", hash = "sha256:bb1a86d4d71425d52d1501b317fe23d45527baed06bd5d5e1a07cd4b60d07b55", size = 25488230, upload-time = "2026-06-14T09:05:30.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/94/878454aefe94328ba7ad808ecd63da8311aae1198da46cfb29f5cfe130a8/basedpyright-1.39.8-py3-none-any.whl", hash = "sha256:a79d89928064bd9023d429b50c625d87d023bacc2fe3932ef6c7bd13b5426048", size = 13182726, upload-time = "2026-06-14T09:05:26.368Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2024.12.14"
 source = { registry = "https://pypi.org/simple" }
@@ -309,6 +321,22 @@ version = "0.3.4"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/fe/32bd864bcb604b0607924a4cf618ed267a0ef21ac9c3e255109256046e1f/multiprocessing_logging-0.3.4-py2.py3-none-any.whl", hash = "sha256:8a5be02b02edbd6fa6e3e89499af7680db69db9e2d8707fcd28d445fa248f23e", size = 8770, upload-time = "2023-02-05T17:06:20.632Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/22/2a5beb4e21417c73233d9f65cf6f3e96e891b80d2f550a8f630ebc6b88c6/nodejs_wheel_binaries-24.16.0.tar.gz", hash = "sha256:c973cb69dc5fd16e6f6dc6e579e2c3d5534e2a1f57619dddf5ba070efa7dde37", size = 8056, upload-time = "2026-05-30T16:52:09.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/d1/68b43b53cd0fa83ae6fd406705023ca988d9e0ca41c724d82e66fbeb2ef6/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:d9f8f677dcf30e37ac244f07869726abe043f01eb0f45722b1df31cc2af7093c", size = 55666374, upload-time = "2026-05-30T16:51:39.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b2/40a989159599080da485de966c4c2d207e852ac7aa7864702626d96c8bf5/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:3d0370fe7120ce9697a4f60d40480d2bd8808d9f30131458d5afc0040d4e5a51", size = 55838487, upload-time = "2026-05-30T16:51:43.383Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a7/cd42174fb5ff6faff7fa8d326a18914d8f232098ab5de055b57c16fa13ca/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:85dc92bbb79c851569c5925dcc2a4c915a034efab375f99e4e7e6bbe9cca8342", size = 60179540, upload-time = "2026-05-30T16:51:47.036Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/c8a1f9ae140aa28df8744d984d01d4b3af7cdd6555af12127f40ceb45a7d/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2f3036292811514ba847b3708492644764f88a833ac425c5f55007014308ddfd", size = 60716262, upload-time = "2026-05-30T16:51:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/7c35b3737f59e36d0249c265397b7bff570519b95301d6e16ea361e904ad/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:db8a8a76ebd2b28ecbfc9ad464baa3707241b9e050a30e2efdf6f60c0f886502", size = 62230592, upload-time = "2026-05-30T16:51:55Z" },
+    { url = "https://files.pythonhosted.org/packages/04/96/d931255cf9d11a84d6b54d882dba7434646467d568ccf070ea3418638df3/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f1a3d8f7b4491cbbd023ba3fc4e901fcca2d9fb80d57f24ba3890de8b1dbac03", size = 62841759, upload-time = "2026-05-30T16:51:59.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7b/8b7a3f41bc255411be30b6d7d288aab8ffd9ea2055db8555ced3548007b9/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_amd64.whl", hash = "sha256:bb136be9944f0662dcf1120f45193a6b75b13fac378971a95cc42c9f879a81aa", size = 42027734, upload-time = "2026-05-30T16:52:03.348Z" },
+    { url = "https://files.pythonhosted.org/packages/17/66/1ed71f1f529b8ca727d42c7ceb9db0bef145ce4a13dfc86fb50aa44f3be6/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_arm64.whl", hash = "sha256:8308940b5edd0a50dc5267ea36ba21c9f668e83fe0d9f293937174d3a7e31c36", size = 39714528, upload-time = "2026-05-30T16:52:06.421Z" },
 ]
 
 [[package]]
@@ -764,11 +792,16 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "basedpyright" },
     { name = "hypothesis" },
     { name = "inline-snapshot" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
+    { name = "ruff" },
+]
+lint = [
+    { name = "basedpyright" },
     { name = "ruff" },
 ]
 test = [
@@ -798,11 +831,16 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "basedpyright", specifier = ">=1.39.8" },
     { name = "hypothesis", specifier = ">=6.62.1" },
     { name = "inline-snapshot", specifier = ">=0.33.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-timeout", specifier = ">=2.2.0" },
+    { name = "ruff", specifier = ">=0.12.5" },
+]
+lint = [
+    { name = "basedpyright", specifier = ">=1.39.8" },
     { name = "ruff", specifier = ">=0.12.5" },
 ]
 test = [

--- a/zabbix_auto_config/macros.py
+++ b/zabbix_auto_config/macros.py
@@ -628,14 +628,14 @@ class MacroMapFileIn(BaseModel):
 
     @field_validator("macros", mode="before")
     @classmethod
-    def _validate_macro_names(cls, macros: Any) -> dict[MacroName, MacroDefIn]:
+    def _validate_macro_names(cls, macros: Any) -> Any:
         """Validate and normalize macro names."""
         if not isinstance(macros, dict):
-            return macros  # pragma: no cover # pydantic error
+            return macros  # pragma: no cover # pydantic handles error
 
         for raw_name, val in list(macros.items()):
             try:
-                macro_name = validate_macro_name(raw_name)
+                macro_name = validate_macro_name(str(raw_name))
             except ValueError as e:
                 logger.error(
                     "Invalid macro name in macro mapping file; skipping",
@@ -644,6 +644,8 @@ class MacroMapFileIn(BaseModel):
                 )
                 del macros[raw_name]
             else:
+                # Insert validated name if different from raw name
+                # and delete raw name
                 if macro_name != raw_name:
                     logger.warning(
                         "Macro name has leading/trailing whitespace; normalizing",

--- a/zabbix_auto_config/pyzabbix/client.py
+++ b/zabbix_auto_config/pyzabbix/client.py
@@ -2246,7 +2246,7 @@ class ZabbixAPIObjectClass:
             if args and kwargs:
                 raise TypeError("Found both args and kwargs")
 
-            return self.parent.do_request(f"{self.name}.{attr}", args or kwargs).result  # type: ignore
+            return self.parent.do_request(f"{self.name}.{attr}", args or kwargs).result
 
         return fn
 


### PR DESCRIPTION
Replace pyright with basedpyright. I think we should use ty at some point, but that requires a larger refactoring of config + `ignore` rules.